### PR TITLE
frr: do not depend on libelf from the host

### DIFF
--- a/recipes-protocols/frr/frr.inc
+++ b/recipes-protocols/frr/frr.inc
@@ -16,6 +16,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
 DEPENDS = " \
            bison-native \
            c-ares \
+           elfutils-native \
            flex-native \
            json-c \
            ncurses \


### PR DESCRIPTION
Add a dependency to elfutils-native to allow clippy to link against
yocto's own libelf instead of requiring the host to have it installed.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>