### PR TITLE
update frr to 8.0.1 and enable ipv6ll by default

### DIFF
--- a/recipes-core/base-files/base-files/30-disable-ipv6-auto-addr-gen.conf
+++ b/recipes-core/base-files/base-files/30-disable-ipv6-auto-addr-gen.conf
@@ -1,2 +1,1 @@
 net.ipv6.conf.default.addr_gen_mode=1
-net.ipv6.conf.all.addr_gen_mode=1

--- a/recipes-core/base-files/base-files/30-disable-ipv6-auto-addr-gen.conf
+++ b/recipes-core/base-files/base-files/30-disable-ipv6-auto-addr-gen.conf
@@ -1,1 +1,0 @@
-net.ipv6.conf.default.addr_gen_mode=1

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,7 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
-   file://30-disable-ipv6-auto-addr-gen.conf \
    file://system-backup.txt \
    file://user-backup.txt \
 "
@@ -13,8 +12,6 @@ do_install_append () {
 # onie
 LABEL=ONIE-BOOT      /mnt/onie-boot       auto       defaults,noauto       0  2
 EOF
-  install -d ${D}${sysconfdir}/sysctl.d
-  install -m 0644 ${WORKDIR}/30-disable-ipv6-auto-addr-gen.conf ${D}${sysconfdir}/sysctl.d/30-disable-ipv6-auto-addr-gen.conf
   install -d ${D}${sysconfdir}/default
   install -m 0644 ${WORKDIR}/system-backup.txt ${D}${sysconfdir}/default/system-backup.txt
   install -m 0644 ${WORKDIR}/user-backup.txt ${D}${sysconfdir}/default/user-backup.txt

--- a/recipes-protocols/frr/clippy-native_8.0.1.bb
+++ b/recipes-protocols/frr/clippy-native_8.0.1.bb
@@ -1,8 +1,8 @@
 require frr.inc
 
 GIT_BRANCH = "stable/8.0"
-# commit hash of release tag frr-8.0
-SRCREV = "9931db75f7730381ad4fba16efd39cbb67749470"
+# commit hash of release tag frr-8.0.1
+SRCREV = "5de7dbc1d56cda6ed392e75e145c170178014dd2"
 
 PR = "r1"
 

--- a/recipes-protocols/frr/frr_8.0.1.bb
+++ b/recipes-protocols/frr/frr_8.0.1.bb
@@ -1,8 +1,8 @@
 require frr.inc
 
 GIT_BRANCH = "stable/8.0"
-# commit hash of release tag frr-8.0
-SRCREV = "9931db75f7730381ad4fba16efd39cbb67749470"
+# commit hash of release tag frr-8.0.1
+SRCREV = "5de7dbc1d56cda6ed392e75e145c170178014dd2"
 
 SRC_URI += " \
 	file://0002-vtysh-fix-searching-commands-in-parent-nodes.patch \


### PR DESCRIPTION
The upstream FRR project changed functionality in the release 8.0.1 by
now requiring IPv6 link local addresses on all interfaces (following
rfc4291). To still allow ipv6 routing by default, we should also follow
this rfc and not disable IPv6 ll addressing.