### PR TITLE
systemd: drop redundant management interface configuration file

### DIFF
--- a/recipes-core/systemd/files/99-enp.network
+++ b/recipes-core/systemd/files/99-enp.network
@@ -1,8 +1,0 @@
-# Automatically bring-up wired interfaces. If possible, get an address using
-# DHCP.
-# See http://www.freedesktop.org/software/systemd/man/systemd.network.html
-[Match]
-Name=enp*
-
-[Network]
-DHCP=v4

--- a/recipes-core/systemd/systemd.inc
+++ b/recipes-core/systemd/systemd.inc
@@ -5,20 +5,14 @@ PACKAGECONFIG_append = " coredump networkd resolved"
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
-    file://99-enp.network \
     file://20-network-io.conf \
 "
 
 FILES_${PN} += "\
-    ${sysconfdir}/systemd/network/* \
     ${sysconfdir}/sysctl.d/20-network-io.conf \
 "
 
 do_install_append() {
-   # systemd-networkd
-   install -d ${D}${sysconfdir}/systemd/network/
-   install -m 0644 ${WORKDIR}/*.network ${D}${sysconfdir}/systemd/network/
-
    # systemd-sysctl
    install -d ${D}${sysconfdir}/sysctl.d/
    install -m 0644 ${WORKDIR}/20-network-io.conf ${D}${sysconfdir}/sysctl.d/


### PR DESCRIPTION
The switch from Yocto warrior to Yocto dunfell brought in a default
wired config wired.network, [link to repo](http://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-core/systemd/systemd-conf/wired.network?h=dunfell), which configures
DHCP on all interfaces starting with eth and en. Since 80 is lower number
than 99, it matches first, and thus always takes precedence before our
99-enp.network, preventing any intended management interface config
from being applied.

Removing the file we package with systemd removes the duplicated
configuration to allow the pre-packaged file taking precendence and applying
the DHCP configuration.

Fixes #13 
Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>