### PR TITLE
distro: update feed defaults to actual nightly location

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -15,8 +15,8 @@ DISTROOVERRIDES = "poky:bisdn-linux"
 EXTRAOPKGCONFIG   = "b-isdn-feed-config-opkg"
 
 FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
-FEEDURIPREFIX  ??= "${DISTRO_VERSION}"
-FEEDDOMAIN     ??= "http://repo.bisdn.de/pub/packages"
+FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/master/packages_latest-build"
+FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
 DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile nfs pci pcmcia systemd usbgadget usbhost virtualization xattr"
 


### PR DESCRIPTION
Set the FEEDDOMAIN and FEEDURIPREFIX to what is used for nightly builds.

This allows up using these in the SRC_URI of binary only packages, and
then only need to update/override these for releases instead of updating
the SRC_URI in the recipes.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>