### PR TITLE
images: full: include en-us locale

### DIFF
--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -46,6 +46,6 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     vim \
     "
 
-IMAGE_LINGUAS = " "
+IMAGE_LINGUAS = "en-us"
 
 LICENSE = "MIT"


### PR DESCRIPTION
Add a default locale of en-us to images, as e.g. tmux requires it.

Without any locales installed, tmux will fail with:

tmux: need UTF-8 locale (LC_TYPE), but have ANSI_X3.4-1968

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>