### PR TITLE
ip6tables: add -w parameter to solve xtables lock

### DIFF
--- a/recipes-extended/iptables/iptables/ip6tables.service
+++ b/recipes-extended/iptables/iptables/ip6tables.service
@@ -5,8 +5,8 @@ Wants=network-pre.target
 
 [Service]
 Type=oneshot
-ExecStart=@SBINDIR@/ip6tables-restore /etc/iptables/ip6tables.rules
-ExecReload=@SBINDIR@/ip6tables-restore /etc/iptables/ip6tables.rules
+ExecStart=@SBINDIR@/ip6tables-restore /etc/iptables/ip6tables.rules -w
+ExecReload=@SBINDIR@/ip6tables-restore /etc/iptables/ip6tables.rules -w
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
There is a lock on xtables when the service starts, so the service
fails. Adding the waiting (-w) parameter when executing will let the
service wait for the lock to be removed.

Signed-off-by: Hilmar Magnusson <hilmar.magnusson@bisdn.de>