### PR TITLE
treewide: switch git transport to https for github

### DIFF
--- a/recipes-devtools/python/python3-oslo.config_git.bb
+++ b/recipes-devtools/python/python3-oslo.config_git.bb
@@ -8,7 +8,7 @@ PV = "4.11.1+git${SRCPV}"
 SRCREV = "fb0738974824af6e1bc7d9fdf32a7c1d3ebf65fb"
 
 SRCNAME = "oslo.config"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/python/python3-ryu_git.bb
+++ b/recipes-devtools/python/python3-ryu_git.bb
@@ -8,7 +8,7 @@ PV = "4.34+git${SRCPV}"
 SRCREV = "c776e4cb68600b2ee0a4f38364f4a355502777f1"
 
 SRCNAME = "ryu"
-SRC_URI = "git://github.com/osrg/${SRCNAME}.git"
+SRC_URI = "git://github.com/osrg/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/baseboxd/baseboxd.inc
+++ b/recipes-extended/baseboxd/baseboxd.inc
@@ -20,7 +20,7 @@ DEPENDS = "\
     systemd \
 "
 
-SRC_URI = "gitsm://github.com/bisdn/basebox.git"
+SRC_URI = "gitsm://github.com/bisdn/basebox.git;protocol=https"
 S = "${WORKDIR}/git"
 
 inherit pkgconfig systemd

--- a/recipes-support/rofl-common/rofl-common.inc
+++ b/recipes-support/rofl-common/rofl-common.inc
@@ -12,7 +12,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-	git://github.com/bisdn/rofl-common.git \
+	git://github.com/bisdn/rofl-common.git;protocol=https \
 	file://001-fix-configure-glog.patch \
         "
 

--- a/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
+++ b/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 DEPENDS = "rofl-common"
 
-SRC_URI = "git://github.com/bisdn/rofl-ofdpa.git"
+SRC_URI = "git://github.com/bisdn/rofl-ofdpa.git;protocol=https"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Github just turned off the git transport on their servers, and checking
out now fails with:

fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

So switch to https to make stuff build again.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>