### PR TITLE
iptables: add -w parameter to solve xtables lock

### DIFF
--- a/recipes-extended/iptables/iptables/iptables.service
+++ b/recipes-extended/iptables/iptables/iptables.service
@@ -5,8 +5,8 @@ Wants=network-pre.target
 
 [Service]
 Type=oneshot
-ExecStart=@SBINDIR@/iptables-restore /etc/iptables/iptables.rules
-ExecReload=@SBINDIR@/iptables-restore /etc/iptables/iptables.rules
+ExecStart=@SBINDIR@/iptables-restore /etc/iptables/iptables.rules -w
+ExecReload=@SBINDIR@/iptables-restore /etc/iptables/iptables.rules -w
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
There is a lock on xtables when the service starts, so the service
fails. Adding the waiting (-w) parameter when executing will let the
service wait for the lock to be removed.

Signed-off-by: Hilmar Magnusson <hilmar.magnusson@bisdn.de>