### PR TITLE
images/full: add rsync

### DIFF
--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -41,6 +41,7 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     python3-pip \
     python3-ryu \
     radvd \
+    rsync \
     run-preinsts \
     tcpdump \
     tmux \


### PR DESCRIPTION
Rsync is much faster than the alternatives, especially when copying
multiple files multiple times.

We don't have a good option for copying test files to (and updating them
on) BISDN Linux.

- scp -r transfers every file whether it is already in the desired state
  or not

- The Ansible copy module is notorious for being inefficient and slow,
  even compared to scp. The recommended alternative is the Ansible
  synchronize module which is just a wrapper around rsync.

Adding rsync increases the image size by 250 KB.

Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>