### PR TITLE
libnl: don't merge IPv6 link local routes into one

### DIFF
--- a/recipes-support/libnl/libnl/0001-mdb-support-bridge-multicast-database-notification.patch
+++ b/recipes-support/libnl/libnl/0001-mdb-support-bridge-multicast-database-notification.patch
@@ -1,7 +1,7 @@
 From 97a91bd7169701e17465d6672581c4d6ee6df12c Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Mon, 20 Jul 2020 10:44:39 +0200
-Subject: [PATCH 1/6] mdb: support bridge multicast database notification
+Subject: [PATCH 1/7] mdb: support bridge multicast database notification
 
 The Linux kernel has a notification system via Netlink that reports the
 changes in the multicast database over the RTNLGRP_MDB multicast socket.
@@ -645,5 +645,5 @@ index a6f21b4..99aa0f4 100644
  };
  
 -- 
-2.32.0
+2.35.1
 

--- a/recipes-support/libnl/libnl/0002-link-bonding-parse-and-expose-bonding-options.patch
+++ b/recipes-support/libnl/libnl/0002-link-bonding-parse-and-expose-bonding-options.patch
@@ -1,7 +1,7 @@
 From 7fd781e1dda943c6324402fd2771ee17cf23e322 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 10:00:37 +0200
-Subject: [PATCH 2/6] link/bonding: parse and expose bonding options
+Subject: [PATCH 2/7] link/bonding: parse and expose bonding options
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -405,5 +405,5 @@ index 900b5e6..37ad514 100644
  	rtnl_mdb_alloc_cache_flags;
  	rtnl_mdb_foreach_entry;
 -- 
-2.32.0
+2.35.1
 

--- a/recipes-support/libnl/libnl/0003-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0003-WIP-add-info-slave-data-support.patch
@@ -1,7 +1,7 @@
 From 38d8c7608eea311d111b245e6ef89bbb988923aa Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
-Subject: [PATCH 3/6] WIP: add info slave data support
+Subject: [PATCH 3/7] WIP: add info slave data support
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -266,5 +266,5 @@ index d406783..7b66a75 100644
  
  /** @} */
 -- 
-2.32.0
+2.35.1
 

--- a/recipes-support/libnl/libnl/0004-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0004-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,7 +1,7 @@
 From c7592e59fb7a46c1c7330275495ed364d0221e9a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
-Subject: [PATCH 4/6] link/bonding: expose state on enslaved interfaces
+Subject: [PATCH 4/7] link/bonding: expose state on enslaved interfaces
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -250,5 +250,5 @@ index 37ad514..62b44ad 100644
  	rtnl_mdb_alloc_cache_flags;
  	rtnl_mdb_foreach_entry;
 -- 
-2.32.0
+2.35.1
 

--- a/recipes-support/libnl/libnl/0005-sync-linux-headers-with-5.11.patch
+++ b/recipes-support/libnl/libnl/0005-sync-linux-headers-with-5.11.patch
@@ -1,7 +1,7 @@
 From 8591d75aacbf3e2859373d4aa39f94d19edeba57 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:22:23 +0200
-Subject: [PATCH 5/6] sync linux headers with 5.11?
+Subject: [PATCH 5/7] sync linux headers with 5.11?
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 ---
@@ -725,5 +725,5 @@ index 8c1d600..98ee2db 100644
  /* End of information exported to user level */
  
 -- 
-2.32.0
+2.35.1
 

--- a/recipes-support/libnl/libnl/0006-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0006-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,7 +1,7 @@
 From b84f561f4c30bd631894066d701166cae226ff1c Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
-Subject: [PATCH 6/6] bridge-vlan: add per vlan stp state object and cache
+Subject: [PATCH 6/7] bridge-vlan: add per vlan stp state object and cache
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Co-authored-by: Jonas Gorski <jonas.gorski@bisdn.de>

--- a/recipes-support/libnl/libnl/0007-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0007-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,0 +1,54 @@
+From fc6ed472edd6bb4d8cd74c0f2f547ac26c153411 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Tue, 1 Mar 2022 12:59:50 +0100
+Subject: [PATCH 7/7] route/route_obj: treat each IPv6 link-local route as
+ different
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/route/route_obj.c | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/lib/route/route_obj.c b/lib/route/route_obj.c
+index bacabe8..f1292d7 100644
+--- a/lib/route/route_obj.c
++++ b/lib/route/route_obj.c
+@@ -363,6 +363,35 @@ static uint32_t route_id_attrs_get(struct nl_object *obj)
+ 	if (route->rt_family == AF_MPLS)
+ 		rv &= ~ROUTE_ATTR_PRIO;
+ 
++	/* pretend link-local IPv6 routes are multipath so that different
++	 * nexthops (OIF) will be treated as different routes */
++	if (route->rt_dst && nl_addr_get_family(route->rt_dst) == AF_INET6) {
++		uint8_t *addr = nl_addr_get_binary_addr(route->rt_dst);
++		unsigned int prefixlen = nl_addr_get_prefixlen(route->rt_dst);
++
++		switch (route->rt_type) {
++		case RTN_UNICAST:
++			if (prefixlen == 64 &&
++			    addr[0] == 0xfe && (addr[1] & 0xc0) == 0x80)
++				/* link-local unicast */
++				rv |= ROUTE_ATTR_MULTIPATH;
++			break;
++		case RTN_ANYCAST:
++			if (prefixlen == 128 &&
++			    addr[0] == 0xfe && (addr[1] & 0xc0) == 0x80)
++				/* link-local anycast */
++				rv |= ROUTE_ATTR_MULTIPATH;
++			break;
++		case RTN_MULTICAST:
++			if (prefixlen == 8 && addr[0] == 0xff)
++				/* multicast */
++				rv |= ROUTE_ATTR_MULTIPATH;
++			break;
++		default:
++			break;
++		}
++	}
++
+ 	return rv;
+ }
+ 
+-- 
+2.35.1
+

--- a/recipes-support/libnl/libnl_3.5.0.bb
+++ b/recipes-support/libnl/libnl_3.5.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r3"
+PR = "r4"
 
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -20,6 +20,7 @@ SRC_URI = " \
     file://0004-link-bonding-expose-state-on-enslaved-interfaces.patch \
     file://0005-sync-linux-headers-with-5.11.patch \
     file://0006-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
+    file://0007-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
 "
 
 # this is actually master:


### PR DESCRIPTION
IPv6 link local routes are per interface, and only differ in the output
interface (interface nexthop in libnl).

By default, the route identity function does not check nexthops, and
treats each new link local route as an update of the previous one.

So to fix it, force it also consider the next hop for routes regarding
link local IPv6 address spaces.

Without the fix:

agema-ag5648:~$ nl-route-list --family inet6
inet6 ::1 table main type unicast via dev lo
inet6 fe80::/64 table main type unicast via dev enp0s20
inet6 ::1 table local type local via dev lo
inet6 fe80:: table local type anycast via dev enp0s20
inet6 fe80::a6:6ff:fecd:ace5 table local type local via dev port7
inet6 fe80::230:abff:fe28:5c85 table local type local via dev enp0s20
inet6 fe80::94f6:beff:fe71:4c32 table local type local via dev port54
inet6 ff00::/8 table local type multicast via dev enp0s20

with the fix:

agema-ag5648:~$ nl-route-list --family inet6
inet6 ::1 table main type unicast via dev lo
inet6 fe80::/64 table main type unicast via dev enp0s20
inet6 fe80::/64 table main type unicast via dev port54
inet6 fe80::/64 table main type unicast via dev port7
inet6 ::1 table local type local via dev lo
inet6 fe80:: table local type anycast via dev enp0s20
inet6 fe80:: table local type anycast via dev port54
inet6 fe80:: table local type anycast via dev port7
inet6 fe80::a6:6ff:fecd:ace5 table local type local via dev port7
inet6 fe80::230:abff:fe28:5c85 table local type local via dev enp0s20
inet6 fe80::94f6:beff:fe71:4c32 table local type local via dev port54
inet6 ff00::/8 table local type multicast via dev enp0s20
inet6 ff00::/8 table local type multicast via dev port54
inet6 ff00::/8 table local type multicast via dev port7

ip route output for comparison:

agema-ag5648:~$ ip -6 route show table all
::1 dev lo proto kernel metric 256 pref medium
fe80::/64 dev enp0s20 proto kernel metric 256 pref medium
fe80::/64 dev port54 proto kernel metric 256 pref medium
fe80::/64 dev port7 proto kernel metric 256 pref medium
local ::1 dev lo table local proto kernel metric 0 pref medium
anycast fe80:: dev enp0s20 table local proto kernel metric 0 pref medium
anycast fe80:: dev port54 table local proto kernel metric 0 pref medium
anycast fe80:: dev port7 table local proto kernel metric 0 pref medium
local fe80::a6:6ff:fecd:ace5 dev port7 table local proto kernel metric 0 pref medium
local fe80::230:abff:fe28:5c85 dev enp0s20 table local proto kernel metric 0 pref medium
local fe80::94f6:beff:fe71:4c32 dev port54 table local proto kernel metric 0 pref medium
multicast ff00::/8 dev enp0s20 table local proto kernel metric 256 pref medium
multicast ff00::/8 dev port54 table local proto kernel metric 256 pref medium
multicast ff00::/8 dev port7 table local proto kernel metric 256 pref medium

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>