### PR TITLE
Set max read buffer size

### DIFF
--- a/recipes-core/systemd/files/20-network-io.conf
+++ b/recipes-core/systemd/files/20-network-io.conf
@@ -1,7 +1,8 @@
-net.core.wmem_default=524288
 net.core.rmem_default=524288
-net.core.optmem_max=65536
+net.core.rmem_max=8388608
+net.core.wmem_default=524288
 net.core.wmem_max=8388608
+net.core.optmem_max=65536
 net.ipv4.ip_forward=1
 net.ipv4.neigh.default.gc_thresh1=8192
 net.ipv4.neigh.default.gc_thresh2=8192


### PR DESCRIPTION
net.core.rmem_max is lower than the rmem_default value, and thus will lead to
loss when baseboxd reads netlink messages, because baseboxd uses the max value
to set its buffer size. Set the rmem_max value to the same as the
wmem_max value.

This should solve [baseboxd issue 376](https://github.com/bisdn/basebox/issues/376)