### PR TITLE
libnl: switch to main branch to fix build

### DIFF
--- a/recipes-support/libnl/libnl_3.5.0.bb
+++ b/recipes-support/libnl/libnl_3.5.0.bb
@@ -13,7 +13,7 @@ DEPENDS = "flex-native bison-native"
 ##https://github.com/thom311/${BPN}/releases/download/${BPN}${@d.getVar('PV').replace('.','_')}/${BP}.tar.gz
 
 SRC_URI = " \
-    git://github.com/thom311/${BPN}.git;protocol=https \
+    git://github.com/thom311/${BPN}.git;protocol=https;branch=main \
     file://0001-mdb-support-bridge-multicast-database-notification.patch \
     file://0002-link-bonding-parse-and-expose-bonding-options.patch \
     file://0003-WIP-add-info-slave-data-support.patch \


### PR DESCRIPTION
Libnl seems to have moved from master to main, with replacing master
with a very old revision(?). So point to main to make it build again.

Fixes the following error:

```
WARNING: libnl-1_3.5.0-r4 do_fetch: Failed to fetch URL git://github.com/thom311/libnl.git;protocol=https, attempting MIRRORS if available
ERROR: libnl-1_3.5.0-r4 do_fetch: Fetcher failure: Unable to find revision 7b167ef85f6eb4d7faca349302478b2dc121e309 in branch master even from upstream
ERROR: libnl-1_3.5.0-r4 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'git://github.com/thom311/libnl.git;protocol=https')
ERROR: Logfile of failure stored in: /tmp/master/work/cortexa9-vfp-poky-linux-gnueabi/libnl/1_3.5.0-r4/temp/log.do_fetch.45463
ERROR: Task (/home/ubuntu/bisdn-linux/master/poky/meta-switch/recipes-support/libnl/libnl_3.5.0.bb:do_fetch) failed with exit code '1'
```

No functional changes, so no PR bump needed.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>