### PR TITLE
grpc: fix checkout by updating googletest branch to main

### DIFF
--- a/recipes-devtools/grpc/grpc_1.24.3.bbappend
+++ b/recipes-devtools/grpc/grpc_1.24.3.bbappend
@@ -5,7 +5,7 @@
 FILESEXTRAPATHS_append := "${THISDIR}/files:"
 
 SRC_URI += " \
-           git://github.com/google/googletest.git;protocol=https;name=gtest;tag=release-1.8.0;destsuffix=git/third_party/googletest \
+           git://github.com/google/googletest.git;protocol=https;name=gtest;tag=release-1.8.0;destsuffix=git/third_party/googletest;branch=main \
            git://github.com/google/benchmark.git;protocol=https;name=benchmark;tag=v1.5.0;destsuffix=git/third_party/benchmark \
            file://1.24.3/force_gflags_libname.patch \
            file://1.24.3/add_grpc_cli_build_option.patch \


### PR DESCRIPTION
Googletest renamed their default branch from master to main, so we need
to update our source definition, else the checkout will fail.

No functional changes, so no PR bump needed.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>