### PR TITLE
update LICENSE to current SPDX identifiers

### DIFF
--- a/recipes-extended/baseboxd/baseboxd.inc
+++ b/recipes-extended/baseboxd/baseboxd.inc
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "A tiny OpenFlow controller for OF-DPA switches"
 HOMEPAGE = "https://github.com/bisdn/basebox"
-LICENSE = "MPLv2"
+LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 DEPENDS = "\

--- a/recipes-protocols/frr/frr.inc
+++ b/recipes-protocols/frr/frr.inc
@@ -9,7 +9,7 @@ NHRP."
 HOMEPAGE = "https://frrouting.org/"
 SECTION = "net"
 
-LICENSE = "GPL-2.0 & LGPL-2.1"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://COPYING-LGPLv2.1;md5=4fbd65380cdd255951079008b364516c"
 

--- a/recipes-support/libnl/libnl_3.5.0.bb
+++ b/recipes-support/libnl/libnl_3.5.0.bb
@@ -5,7 +5,7 @@ SECTION = "libs/network"
 PE = "1"
 PR = "r4"
 
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS = "flex-native bison-native"

--- a/recipes-support/mstpd/mstpd_git.bb
+++ b/recipes-support/mstpd/mstpd_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Multiple Spanning Tree Protocol Daemon"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4325afd396febcb659c36b49533135d4"
 
 SRC_URI = "\

--- a/recipes-support/rofl-common/rofl-common.inc
+++ b/recipes-support/rofl-common/rofl-common.inc
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "OpenFlow protocol endpoint written in C++"
 HOMEPAGE = "https://github.com/bisdn/rofl-common"
-LICENSE = "MPLv2"
+LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=5d425c8f3157dbf212db2ec53d9e5132"
 
 DEPENDS = " \

--- a/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
+++ b/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "Convenience library to interact with Broadcom OF-DPA based switches"
 HOMEPAGE = "https://github.com/bisdn/rofl-ofdpa"
-LICENSE = "MPLv2"
+LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 DEPENDS = "rofl-common"


### PR DESCRIPTION
Update all of our recipes to use the correct, current SPDX license identifiers, based on https://spdx.org/licenses/ (Version: 3.16 2022-02-06).

Mostly FOOvX => FOO-X and GPL-2.0 refined into 2.0-only or 2.0-or-later.

Packages imported from upstream were intentionally left untouched.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>