### PR TITLE
images/minimal: add sftp and sftp-server

### DIFF
--- a/recipes-core/images/minimal.bb
+++ b/recipes-core/images/minimal.bb
@@ -19,6 +19,8 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL = "\
     less \
     onie-tools \
     onl \
+    openssh-sftp \
+    openssh-sftp-server \
     parted \
     strace \
     util-linux \


### PR DESCRIPTION
OpenSSH 9.0 defaults to the SFTP protocol even when using the scp
binary, unless explicitly told to use SCP via an option.

Since we are not strapped for space, let's just add the appropriate
sftp-server package to the image (and client as well) to allow seamless
upgrades of OpenSSH to 9.0+ on host systems.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>