### PR TITLE
libnl: handle default route destinations in nla_put_addr()

### DIFF
--- a/recipes-support/libnl/libnl/0001-mdb-support-bridge-multicast-database-notification.patch
+++ b/recipes-support/libnl/libnl/0001-mdb-support-bridge-multicast-database-notification.patch
@@ -1,7 +1,7 @@
 From 97a91bd7169701e17465d6672581c4d6ee6df12c Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Mon, 20 Jul 2020 10:44:39 +0200
-Subject: [PATCH 1/7] mdb: support bridge multicast database notification
+Subject: [PATCH 1/8] mdb: support bridge multicast database notification
 
 The Linux kernel has a notification system via Netlink that reports the
 changes in the multicast database over the RTNLGRP_MDB multicast socket.
@@ -25,7 +25,7 @@ in order to expose the contents of the multicast database.
  create mode 100644 lib/route/mdb.c
 
 diff --git a/Makefile.am b/Makefile.am
-index b2e8737..1d70059 100644
+index b2e87379ca1f..1d7005974b62 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -105,6 +105,7 @@ libnlinclude_netlink_route_HEADERS = \
@@ -53,7 +53,7 @@ index b2e8737..1d70059 100644
  	lib/route/nh_encap_mpls.c \
  	lib/route/pktloc.c \
 diff --git a/include/netlink-private/types.h b/include/netlink-private/types.h
-index 97af3e5..c2f28d4 100644
+index 97af3e51bd74..c2f28d4ae463 100644
 --- a/include/netlink-private/types.h
 +++ b/include/netlink-private/types.h
 @@ -1338,4 +1338,22 @@ struct rtnl_vlan
@@ -81,7 +81,7 @@ index 97af3e5..c2f28d4 100644
  #endif
 diff --git a/include/netlink/cli/mdb.h b/include/netlink/cli/mdb.h
 new file mode 100644
-index 0000000..cd37604
+index 000000000000..cd37604a5eaa
 --- /dev/null
 +++ b/include/netlink/cli/mdb.h
 @@ -0,0 +1,11 @@
@@ -98,7 +98,7 @@ index 0000000..cd37604
 +#endif
 diff --git a/include/netlink/route/mdb.h b/include/netlink/route/mdb.h
 new file mode 100644
-index 0000000..fc518bb
+index 000000000000..fc518bbf5433
 --- /dev/null
 +++ b/include/netlink/route/mdb.h
 @@ -0,0 +1,43 @@
@@ -147,7 +147,7 @@ index 0000000..fc518bb
 +#endif
 diff --git a/lib/route/mdb.c b/lib/route/mdb.c
 new file mode 100644
-index 0000000..9c3fa20
+index 000000000000..9c3fa20b495f
 --- /dev/null
 +++ b/lib/route/mdb.c
 @@ -0,0 +1,452 @@
@@ -604,7 +604,7 @@ index 0000000..9c3fa20
 +
 +/** @} */
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index 4a65503..900b5e6 100644
+index 4a65503f1616..900b5e66ddee 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
 @@ -1150,3 +1150,16 @@ global:
@@ -625,7 +625,7 @@ index 4a65503..900b5e6 100644
 +	rtnl_mdb_entry_get_vid;
 +} libnl_3_5;
 diff --git a/src/nl-monitor.c b/src/nl-monitor.c
-index a6f21b4..99aa0f4 100644
+index a6f21b4a775d..99aa0f43cc83 100644
 --- a/src/nl-monitor.c
 +++ b/src/nl-monitor.c
 @@ -12,6 +12,7 @@
@@ -645,5 +645,5 @@ index a6f21b4..99aa0f4 100644
  };
  
 -- 
-2.35.1
+2.36.1
 

--- a/recipes-support/libnl/libnl/0002-link-bonding-parse-and-expose-bonding-options.patch
+++ b/recipes-support/libnl/libnl/0002-link-bonding-parse-and-expose-bonding-options.patch
@@ -1,7 +1,7 @@
 From 7fd781e1dda943c6324402fd2771ee17cf23e322 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 10:00:37 +0200
-Subject: [PATCH 2/7] link/bonding: parse and expose bonding options
+Subject: [PATCH 2/8] link/bonding: parse and expose bonding options
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  3 files changed, 344 insertions(+), 1 deletion(-)
 
 diff --git a/include/netlink/route/link/bonding.h b/include/netlink/route/link/bonding.h
-index 5c34662..a68cf1e 100644
+index 5c34662df7b3..a68cf1e28e9b 100644
 --- a/include/netlink/route/link/bonding.h
 +++ b/include/netlink/route/link/bonding.h
 @@ -31,6 +31,18 @@ extern int	rtnl_link_bond_enslave(struct nl_sock *, struct rtnl_link *,
@@ -34,7 +34,7 @@ index 5c34662..a68cf1e 100644
  }
  #endif
 diff --git a/lib/route/link/bonding.c b/lib/route/link/bonding.c
-index 11b6d3d..0774223 100644
+index 11b6d3d12e2b..0774223b1917 100644
 --- a/lib/route/link/bonding.c
 +++ b/lib/route/link/bonding.c
 @@ -25,6 +25,153 @@
@@ -377,7 +377,7 @@ index 11b6d3d..0774223 100644
  {
  	rtnl_link_register_info(&bonding_info_ops);
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index 900b5e6..37ad514 100644
+index 900b5e66ddee..37ad514a5d21 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
 @@ -232,7 +232,6 @@ global:
@@ -405,5 +405,5 @@ index 900b5e6..37ad514 100644
  	rtnl_mdb_alloc_cache_flags;
  	rtnl_mdb_foreach_entry;
 -- 
-2.35.1
+2.36.1
 

--- a/recipes-support/libnl/libnl/0003-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0003-WIP-add-info-slave-data-support.patch
@@ -1,7 +1,7 @@
 From 38d8c7608eea311d111b245e6ef89bbb988923aa Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
-Subject: [PATCH 3/7] WIP: add info slave data support
+Subject: [PATCH 3/8] WIP: add info slave data support
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -12,7 +12,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  4 files changed, 127 insertions(+)
 
 diff --git a/include/netlink-private/route/link/api.h b/include/netlink-private/route/link/api.h
-index 6d30bf7..48eec75 100644
+index 6d30bf7c4798..48eec7553819 100644
 --- a/include/netlink-private/route/link/api.h
 +++ b/include/netlink-private/route/link/api.h
 @@ -64,6 +64,39 @@ struct rtnl_link_info_ops
@@ -67,7 +67,7 @@ index 6d30bf7..48eec75 100644
  }
  #endif
 diff --git a/include/netlink-private/types.h b/include/netlink-private/types.h
-index c2f28d4..eec2e83 100644
+index c2f28d4ae463..eec2e83882ae 100644
 --- a/include/netlink-private/types.h
 +++ b/include/netlink-private/types.h
 @@ -217,8 +217,10 @@ struct rtnl_link
@@ -82,7 +82,7 @@ index c2f28d4..eec2e83 100644
  	uint32_t			l_promiscuity;
  	uint32_t			l_num_tx_queues;
 diff --git a/lib/route/link.c b/lib/route/link.c
-index df01a71..211573d 100644
+index df01a71a35f4..211573d819bc 100644
 --- a/lib/route/link.c
 +++ b/lib/route/link.c
 @@ -263,12 +263,29 @@ static void release_link_info(struct rtnl_link *link)
@@ -233,7 +233,7 @@ index df01a71..211573d 100644
  
  /**
 diff --git a/lib/route/link/api.c b/lib/route/link/api.c
-index d406783..7b66a75 100644
+index d406783e2ea6..7b66a75af1ed 100644
 --- a/lib/route/link/api.c
 +++ b/lib/route/link/api.c
 @@ -413,6 +413,28 @@ int rtnl_link_info_data_compare(struct rtnl_link *a, struct rtnl_link *b, int fl
@@ -266,5 +266,5 @@ index d406783..7b66a75 100644
  
  /** @} */
 -- 
-2.35.1
+2.36.1
 

--- a/recipes-support/libnl/libnl/0004-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0004-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,7 +1,7 @@
 From c7592e59fb7a46c1c7330275495ed364d0221e9a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
-Subject: [PATCH 4/7] link/bonding: expose state on enslaved interfaces
+Subject: [PATCH 4/8] link/bonding: expose state on enslaved interfaces
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  3 files changed, 185 insertions(+)
 
 diff --git a/include/netlink/route/link/bonding.h b/include/netlink/route/link/bonding.h
-index a68cf1e..1719e36 100644
+index a68cf1e28e9b..1719e3674b5f 100644
 --- a/include/netlink/route/link/bonding.h
 +++ b/include/netlink/route/link/bonding.h
 @@ -43,6 +43,9 @@ extern int	rtnl_link_bond_get_primary(struct rtnl_link *, uint32_t *);
@@ -25,7 +25,7 @@ index a68cf1e..1719e36 100644
  }
  #endif
 diff --git a/lib/route/link/bonding.c b/lib/route/link/bonding.c
-index 0774223..65d54af 100644
+index 0774223b1917..65d54afd7362 100644
 --- a/lib/route/link/bonding.c
 +++ b/lib/route/link/bonding.c
 @@ -172,6 +172,120 @@ static int bond_compare(struct rtnl_link *link_a, struct rtnl_link *link_b,
@@ -237,7 +237,7 @@ index 0774223..65d54af 100644
  {
  	rtnl_link_register_info(&bonding_info_ops);
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index 37ad514..62b44ad 100644
+index 37ad514a5d21..62b44ad1c9d8 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
 @@ -1160,6 +1160,8 @@ libnl_3_6 {
@@ -250,5 +250,5 @@ index 37ad514..62b44ad 100644
  	rtnl_mdb_alloc_cache_flags;
  	rtnl_mdb_foreach_entry;
 -- 
-2.35.1
+2.36.1
 

--- a/recipes-support/libnl/libnl/0005-sync-linux-headers-with-5.11.patch
+++ b/recipes-support/libnl/libnl/0005-sync-linux-headers-with-5.11.patch
@@ -1,7 +1,7 @@
 From 8591d75aacbf3e2859373d4aa39f94d19edeba57 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:22:23 +0200
-Subject: [PATCH 5/7] sync linux headers with 5.11?
+Subject: [PATCH 5/8] sync linux headers with 5.11?
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
  2 files changed, 519 insertions(+), 27 deletions(-)
 
 diff --git a/include/linux-private/linux/if_bridge.h b/include/linux-private/linux/if_bridge.h
-index bdfecf9..fee6e45 100644
+index bdfecf941132..fee6e4563e9b 100644
 --- a/include/linux-private/linux/if_bridge.h
 +++ b/include/linux-private/linux/if_bridge.h
 @@ -120,6 +120,8 @@ enum {
@@ -525,7 +525,7 @@ index bdfecf9..fee6e45 100644
 +};
  #endif /* _LINUX_IF_BRIDGE_H */
 diff --git a/include/linux-private/linux/rtnetlink.h b/include/linux-private/linux/rtnetlink.h
-index 8c1d600..98ee2db 100644
+index 8c1d600bfa33..98ee2db01962 100644
 --- a/include/linux-private/linux/rtnetlink.h
 +++ b/include/linux-private/linux/rtnetlink.h
 @@ -157,6 +157,27 @@ enum {
@@ -725,5 +725,5 @@ index 8c1d600..98ee2db 100644
  /* End of information exported to user level */
  
 -- 
-2.35.1
+2.36.1
 

--- a/recipes-support/libnl/libnl/0006-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0006-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,7 +1,7 @@
 From b84f561f4c30bd631894066d701166cae226ff1c Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
-Subject: [PATCH 6/7] bridge-vlan: add per vlan stp state object and cache
+Subject: [PATCH 6/8] bridge-vlan: add per vlan stp state object and cache
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Co-authored-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -26,7 +26,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  create mode 100644 src/nl-bridge.c
 
 diff --git a/Makefile.am b/Makefile.am
-index 1d70059..77d796c 100644
+index 1d7005974b62..77d796c906af 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -102,6 +102,7 @@ libnlinclude_netlink_routedir = $(libnlincludedir)/netlink/route
@@ -79,7 +79,7 @@ index 1d70059..77d796c 100644
  src_nl_class_add_LDADD =            $(src_ldadd)
  src_nl_class_delete_CPPFLAGS =      $(src_cppflags)
 diff --git a/include/netlink-private/types.h b/include/netlink-private/types.h
-index eec2e83..ad50032 100644
+index eec2e83882ae..ad500324a822 100644
 --- a/include/netlink-private/types.h
 +++ b/include/netlink-private/types.h
 @@ -1358,4 +1358,15 @@ struct rtnl_mdb_entry {
@@ -100,7 +100,7 @@ index eec2e83..ad50032 100644
  #endif
 diff --git a/include/netlink/cli/bridge_vlan.h b/include/netlink/cli/bridge_vlan.h
 new file mode 100644
-index 0000000..8d3adbd
+index 000000000000..8d3adbd8cf1f
 --- /dev/null
 +++ b/include/netlink/cli/bridge_vlan.h
 @@ -0,0 +1,23 @@
@@ -129,7 +129,7 @@ index 0000000..8d3adbd
 +#endif
 diff --git a/include/netlink/route/bridge_vlan.h b/include/netlink/route/bridge_vlan.h
 new file mode 100644
-index 0000000..62f2994
+index 000000000000..62f2994c7d85
 --- /dev/null
 +++ b/include/netlink/route/bridge_vlan.h
 @@ -0,0 +1,42 @@
@@ -177,7 +177,7 @@ index 0000000..62f2994
 +#endif
 diff --git a/lib/route/bridge_vlan.c b/lib/route/bridge_vlan.c
 new file mode 100644
-index 0000000..36c2b49
+index 000000000000..36c2b490732f
 --- /dev/null
 +++ b/lib/route/bridge_vlan.c
 @@ -0,0 +1,361 @@
@@ -543,7 +543,7 @@ index 0000000..36c2b49
 +
 +/** @} */
 diff --git a/libnl-cli-3.sym b/libnl-cli-3.sym
-index 71ff2eb..ed3bf34 100644
+index 71ff2ebebaa2..ed3bf3437bb9 100644
 --- a/libnl-cli-3.sym
 +++ b/libnl-cli-3.sym
 @@ -114,4 +114,7 @@ global:
@@ -555,7 +555,7 @@ index 71ff2eb..ed3bf34 100644
 +	nl_cli_bridge_vlan_parse_ifindex;
  } libnl_3;
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index 62b44ad..21a23a2 100644
+index 62b44ad1c9d8..21a23a27c15b 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
 @@ -1172,4 +1172,17 @@ libnl_3_6 {
@@ -577,7 +577,7 @@ index 62b44ad..21a23a2 100644
 +	rtnl_bridge_vlan_set_vlan_id;
  } libnl_3_5;
 diff --git a/src/.gitignore b/src/.gitignore
-index e53eb3d..31ec86e 100644
+index e53eb3d10b73..31ec86e0c097 100644
 --- a/src/.gitignore
 +++ b/src/.gitignore
 @@ -12,6 +12,7 @@ nf-queue
@@ -590,7 +590,7 @@ index e53eb3d..31ec86e 100644
  nl-class-list
 diff --git a/src/lib/bridge_vlan.c b/src/lib/bridge_vlan.c
 new file mode 100644
-index 0000000..7f90a7f
+index 000000000000..7f90a7f997bd
 --- /dev/null
 +++ b/src/lib/bridge_vlan.c
 @@ -0,0 +1,42 @@
@@ -638,7 +638,7 @@ index 0000000..7f90a7f
 +}
 diff --git a/src/nl-bridge.c b/src/nl-bridge.c
 new file mode 100644
-index 0000000..32530fe
+index 000000000000..32530fe9d3ca
 --- /dev/null
 +++ b/src/nl-bridge.c
 @@ -0,0 +1,38 @@
@@ -681,7 +681,7 @@ index 0000000..32530fe
 +	return 0;
 +}
 diff --git a/src/nl-monitor.c b/src/nl-monitor.c
-index 99aa0f4..a9e40c9 100644
+index 99aa0f43cc83..a9e40c9f647a 100644
 --- a/src/nl-monitor.c
 +++ b/src/nl-monitor.c
 @@ -38,6 +38,7 @@ static const struct {
@@ -693,5 +693,5 @@ index 99aa0f4..a9e40c9 100644
  };
  
 -- 
-2.35.1
+2.36.1
 

--- a/recipes-support/libnl/libnl/0007-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0007-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,7 +1,7 @@
 From fc6ed472edd6bb4d8cd74c0f2f547ac26c153411 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 1 Mar 2022 12:59:50 +0100
-Subject: [PATCH 7/7] route/route_obj: treat each IPv6 link-local route as
+Subject: [PATCH 7/8] route/route_obj: treat each IPv6 link-local route as
  different
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -10,7 +10,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 29 insertions(+)
 
 diff --git a/lib/route/route_obj.c b/lib/route/route_obj.c
-index bacabe8..f1292d7 100644
+index bacabe85d6df..f1292d7e0b90 100644
 --- a/lib/route/route_obj.c
 +++ b/lib/route/route_obj.c
 @@ -363,6 +363,35 @@ static uint32_t route_id_attrs_get(struct nl_object *obj)
@@ -50,5 +50,5 @@ index bacabe8..f1292d7 100644
  }
  
 -- 
-2.35.1
+2.36.1
 

--- a/recipes-support/libnl/libnl/0008-lib-handle-default-route-destinations-in-nla_put_add.patch
+++ b/recipes-support/libnl/libnl/0008-lib-handle-default-route-destinations-in-nla_put_add.patch
@@ -1,0 +1,59 @@
+From a8e0510db8a4d10a0fc8868d8965f1442f6ee069 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 25 May 2022 12:42:13 +0200
+Subject: [PATCH 8/8] lib: handle default route destinations in nla_put_addr()
+
+Default routes (0.0.0.0/0 and ::/0) won't have any data allocated, so
+their data length is zero. This causes nla_put_addr() to generate a
+zero-length address attribute, which is rightfully rejected by the
+kernel.
+
+So in case we we get an address with a zero-length prefix, just allocate
+an appropriate sized attribute for the address family. Since nla_reserve
+initializes the attribute, we don't need to do anything with it.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/attr.c | 26 ++++++++++++++++++++++++--
+ 1 file changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/lib/attr.c b/lib/attr.c
+index a4f585275f1c..4ebe4b130982 100644
+--- a/lib/attr.c
++++ b/lib/attr.c
+@@ -549,8 +549,30 @@ int nla_put_data(struct nl_msg *msg, int attrtype, const struct nl_data *data)
+  */
+ int nla_put_addr(struct nl_msg *msg, int attrtype, struct nl_addr *addr)
+ {
+-	return nla_put(msg, attrtype, nl_addr_get_len(addr),
+-		       nl_addr_get_binary_addr(addr));
++	int addrlen = 0;
++
++	if (nl_addr_get_prefixlen(addr) > 0)
++		return nla_put(msg, attrtype, nl_addr_get_len(addr),
++			       nl_addr_get_binary_addr(addr));
++
++	switch (nl_addr_get_family(addr)) {
++		case AF_INET:
++			addrlen = 4;
++			break;
++		case AF_INET6:
++			addrlen = 16;
++			break;
++		default:
++			return -NLE_INVAL;
++	}
++
++	/* memory will be set to 0 already, so we don't need to do anything
++	 * with it.
++	 */
++	if (nla_reserve(msg, attrtype, addrlen) == NULL)
++		return -NLE_NOMEM;
++
++	return 0;
+ }
+ 
+ /** @} */
+-- 
+2.36.1
+

--- a/recipes-support/libnl/libnl_3.5.0.bb
+++ b/recipes-support/libnl/libnl_3.5.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r4"
+PR = "r5"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -21,6 +21,7 @@ SRC_URI = " \
     file://0005-sync-linux-headers-with-5.11.patch \
     file://0006-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
     file://0007-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
+    file://0008-lib-handle-default-route-destinations-in-nla_put_add.patch \
 "
 
 # this is actually master:


### PR DESCRIPTION
Default routes (0.0.0.0/0 and ::/0) won't have any data allocated, so
their data length is zero. This causes nla_put_addr() to generate a
zero-length address attribute, which is rightfully rejected by the
kernel.

So in case we we get an address with a zero-length prefix, just allocate
an appropriate sized attribute for the address family. Since nla_reserve
initializes the attribute, we don't need to do anything with it.

Fixes crashes when trying to query the kernel for the route to a default
route / zero length prefix.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>