### PR TITLE
always set a branch for git source repos

### DIFF
--- a/recipes-devtools/python/python3-ryu_git.bb
+++ b/recipes-devtools/python/python3-ryu_git.bb
@@ -9,7 +9,7 @@ PR = "r1"
 SRCREV = "c776e4cb68600b2ee0a4f38364f4a355502777f1"
 
 SRCNAME = "ryu"
-SRC_URI = "git://github.com/osrg/${SRCNAME}.git;protocol=https"
+SRC_URI = "git://github.com/osrg/${SRCNAME}.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/baseboxd/baseboxd.inc
+++ b/recipes-extended/baseboxd/baseboxd.inc
@@ -20,7 +20,7 @@ DEPENDS = "\
     systemd \
 "
 
-SRC_URI = "gitsm://github.com/bisdn/basebox.git;protocol=https"
+SRC_URI = "gitsm://github.com/bisdn/basebox.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 
 inherit pkgconfig systemd

--- a/recipes-support/libyang/libyang2_2.0.7.bb
+++ b/recipes-support/libyang/libyang2_2.0.7.bb
@@ -17,7 +17,7 @@ DEBIAN_NOAUTONAME_${PN}-utils = "1"
 DEBIAN_NOAUTONAME_${PN}-dbg = "1"
 
 SRC_URI = " \
-    git://github.com/CESNET/libyang.git;protocol=https \
+    git://github.com/CESNET/libyang.git;protocol=https;branch=master \
     file://0001-cmake-use-pkg-config-for-extracting-pcre2-version.patch \
 "
 

--- a/recipes-support/rofl-common/rofl-common.inc
+++ b/recipes-support/rofl-common/rofl-common.inc
@@ -12,7 +12,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-	git://github.com/bisdn/rofl-common.git;protocol=https \
+	git://github.com/bisdn/rofl-common.git;protocol=https;branch=master \
 	file://001-fix-configure-glog.patch \
         "
 

--- a/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
+++ b/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 DEPENDS = "rofl-common"
 
-SRC_URI = "git://github.com/bisdn/rofl-ofdpa.git;protocol=https"
+SRC_URI = "git://github.com/bisdn/rofl-ofdpa.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
There is a move from master to main for the default branch in git repos,
so the assumption that no branch set means master is less and less true.

Newer bitbake versions warn about the absence of a branch, and likely
will eventually fail if none is set, so set it explicitly to master.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>