### PR TITLE
base-files: backup /etc/gshadow as well

### DIFF
--- a/recipes-core/base-files/base-files/system-backup.txt
+++ b/recipes-core/base-files/base-files/system-backup.txt
@@ -3,6 +3,7 @@
 /etc/passwd
 /etc/shadow
 /etc/group
+/etc/gshadow
 /etc/sudoers.d
 /etc/systemd/network/
 /etc/ofdpa-grpc.conf


### PR DESCRIPTION
We need to make sure that we take over /etc/gshadow as well, else
/etc/groups and /etc/gshadow might get out of sync.

Fixes: c37e24ae5fde ("base-files: add default backup file lists")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>