### PR TITLE
basebox-user: use pre-computed password hash

### DIFF
--- a/recipes-core/basebox-user/basebox-user.bb
+++ b/recipes-core/basebox-user/basebox-user.bb
@@ -9,8 +9,9 @@ RDEPENDS_${PN} = "sudo"
 inherit useradd
 
 USER = "basebox"
-PASSWORD = "b-isdn"
-USERADD_PARAM_${PN} = "-P ${PASSWORD} ${USER}"
+# generated with openssl passwd -6 b-isdn
+PASSWORD = "$6$2zTHd7.l2MZBTq5j$LAwBkh6ILoFcqQyKhwzWe/jm.y/R3Mv0tsOhEbssq.ZLNiXivGpQUmKUWJSvoncQMj/jboLCQAH689wRfUy18."
+USERADD_PARAM_${PN} = "-p '${PASSWORD}' ${USER}"
 USERADD_PACKAGES = "${PN}"
 
 do_install () {


### PR DESCRIPTION
Supplying a plain-text password is a yocto-proprietary extension that
got removed in later releases. So switch to supplying a pregenerated
hashed password with the standard option -p.

While we could generate the password hash dynamically, this would break
reproducability.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>