### PR TITLE
basebox-user: fix password generation

### DIFF
--- a/recipes-core/basebox-user/basebox-user.bb
+++ b/recipes-core/basebox-user/basebox-user.bb
@@ -10,7 +10,7 @@ inherit useradd
 
 USER = "basebox"
 # generated with openssl passwd -6 b-isdn
-PASSWORD = "$6$2zTHd7.l2MZBTq5j$LAwBkh6ILoFcqQyKhwzWe/jm.y/R3Mv0tsOhEbssq.ZLNiXivGpQUmKUWJSvoncQMj/jboLCQAH689wRfUy18."
+PASSWORD = "\$6\$2zTHd7.l2MZBTq5j\$LAwBkh6ILoFcqQyKhwzWe/jm.y/R3Mv0tsOhEbssq.ZLNiXivGpQUmKUWJSvoncQMj/jboLCQAH689wRfUy18."
 USERADD_PARAM_${PN} = "-p '${PASSWORD}' ${USER}"
 USERADD_PACKAGES = "${PN}"
 


### PR DESCRIPTION
While the string makes it fine into the script for generating the
password, the single quotes still not prevent the $ from being
interpreted, so escape them to make sure the hash is correctly set.

Fixes: 4f2ed35fa0e8 ("basebox-user: use pre-computed password hash")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>