### PR TITLE
ryu: fix syntax error in ofctl_v1_3.py

### DIFF
--- a/recipes-devtools/python/python3-ryu/0003-ryu-lib-ofctl_v1_3.py-add-ofdpa-match-fields.patch
+++ b/recipes-devtools/python/python3-ryu/0003-ryu-lib-ofctl_v1_3.py-add-ofdpa-match-fields.patch
@@ -28,7 +28,7 @@ index 91ae9a0f..fd908cd3 100644
                 'pbb_isid': ofctl_utils.to_match_masked_int,
                 'tunnel_id': ofctl_utils.to_match_masked_int,
 -               'ipv6_exthdr': ofctl_utils.to_match_masked_int}
-+               'ipv6_exthdr': ofctl_utils.to_match_masked_int
++               'ipv6_exthdr': ofctl_utils.to_match_masked_int,
 +               'ofdpa_mpls_l2_port': str_to_int,
 +               'ofdpa_mpls_type': str_to_int,
 +               'ofdpa_allow_vlan_translation': str_to_int}


### PR DESCRIPTION
Syntax errors such as the one fixed by this commit are not caught by
setuptools [1]. It was only visible in bitbake's log.do_install:

    File "/usr/lib/python3.8/site-packages/ryu/lib/ofctl_v1_3.py", line 244
      'ofdpa_mpls_l2_port': str_to_int,
      ^
  SyntaxError: invalid syntax

None of our tests failed due to this error. It would have been caught
earlier had the code been checked with pylint before having git create
the patch series.

[1] https://github.com/pypa/setuptools/issues/1637