### PR TITLE
libyang2: explicitly enable pkg-config

### DIFF
--- a/recipes-support/libyang/libyang2_2.0.194.bb
+++ b/recipes-support/libyang/libyang2_2.0.194.bb
@@ -40,4 +40,4 @@ FILES_${PN}-utils = " \
   ${bindir}/yangre \
 "
 
-inherit cmake
+inherit cmake pkgconfig


### PR DESCRIPTION
Newer Yocto versions won't provide pkg-config by default, so we need to
make sure that we inherit the appropriate class.

Without it, libyang2 will not have a the pkg-config available, and will
not generate a libyang.pc.

This will then cause depending packages like frr to fail detect
libyang2:

```
| checking for LIBYANG (libyang >= 2.0.0)... no
| configure: error: libyang (>= 2.0.0) was not found on your system.
| NOTE: The following config.log files may provide further information.
| NOTE: /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/frr/8.2.2-r0/build/config.log
| ERROR: configure failed
| WARNING: exit code 1 from a shell command.
ERROR: Task (/home/ubuntu/bisdn-linux/kirkstone/poky/meta-switch/recipes-protocols/frr/frr_8.2.2.bb:do_configure) failed with exit code '1'
```

From the config.log:

```
configure:24498: checking for LIBYANG (libyang >= 2.0.0)
configure:24505: $PKG_CONFIG --exists --print-errors "libyang >= 2.0.0"
Package libyang was not found in the pkg-config search path.
Perhaps you should add the directory containing `libyang.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libyang' found
```

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>