### PR TITLE
baseboxd: update to 1.11.10

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_1.11.10.bb
+++ b/recipes-extended/baseboxd/baseboxd_1.11.10.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "1580d8f3db949e83379e5e3c0f9611479119c544"
+SRCREV = "19f307606bcf4c44af403cabe8b0934266098c7f"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 1.11.10:

  19f307606bcf Bump version to 1.11.10
  c87e9042be52 nl_bridge: rename outermost loop variable to i
  6f9db0e5f12b nl_bridge: use {vlan,untagged}_new where possible
  4279554a58d0 nl_bridge: rename a,b,c,d variables
  956939d0e422 nl_bridge: update_vlans: use a variable for the vid mask
  82d01005baf2 nl_bridge: avoid undefined behaviour when shifting by 31 bits
  2235ea55bd4e nl_bridge: update_vlans: rewrite while loops as for loops

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>