### PR TITLE
mstpd: update to 0.1.0+bisdn3

### DIFF
--- a/recipes-support/mstpd/mstpd_git.bb
+++ b/recipes-support/mstpd/mstpd_git.bb
@@ -4,11 +4,11 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4325afd396febcb659c36b49533135d4"
 
 SRC_URI = "\
-  git://github.com/bisdn/mstpd.git;branch=0.1.0+bisdn2;protocol=https \
+  git://github.com/bisdn/mstpd.git;branch=0.1.0+bisdn3;protocol=https \
   file://bridge-stp.conf"
 
-PV = "0.1.0+bisdn2"
-SRCREV = "e792ae914753adab08e1f4ebee3b6ed87e6c5474"
+PV = "0.1.0+bisdn3"
+SRCREV = "b2cb344b5f4df808110e2abd5513315cf9349b2e"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update to 0.1.0+bisdn3:

* b2cb344b5f4d release: update for 0.1.0+bisdn3
* 57f87d5f487d brmon: do not use the monitor socket for getting the vlan table

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>