### PR TITLE
frr: update to 8.3

### DIFF
--- a/recipes-protocols/frr/clippy-native_8.3.bb
+++ b/recipes-protocols/frr/clippy-native_8.3.bb
@@ -1,8 +1,8 @@
 require frr.inc
 
-GIT_BRANCH = "stable/8.2"
-# commit hash of release tag frr-8.2.2
-SRCREV = "79188bf710e92acf42fb5b9b0a2e9593a5ee9b05"
+GIT_BRANCH = "stable/8.3"
+# commit hash of release tag frr-8.3
+SRCREV = "d66a1ca8da269a4de0084db45c5a9fc3352ae16c"
 
 PR = "r0"
 

--- a/recipes-protocols/frr/files/support_bundle_commands.conf
+++ b/recipes-protocols/frr/files/support_bundle_commands.conf
@@ -78,6 +78,7 @@ show debugging hashtable
 show running-config
 show thread cpu
 show thread poll
+show thread timers
 show daemons
 show version
 CMD_LIST_END
@@ -176,6 +177,7 @@ show ip igmp groups
 show ip igmp interface
 show ip igmp join
 show ip igmp sources
+show ip igmp statistics
 show ip pim upstream
 show ip mroute
 show ip pim join

--- a/recipes-protocols/frr/frr_8.3.bb
+++ b/recipes-protocols/frr/frr_8.3.bb
@@ -1,8 +1,8 @@
 require frr.inc
 
-GIT_BRANCH = "stable/8.2"
-# commit hash of release tag frr-8.2.2
-SRCREV = "79188bf710e92acf42fb5b9b0a2e9593a5ee9b05"
+GIT_BRANCH = "stable/8.3"
+# commit hash of release tag frr-8.3
+SRCREV = "d66a1ca8da269a4de0084db45c5a9fc3352ae16c"
 
 PR="r0"
 


### PR DESCRIPTION
* update to frr 8.3
* apply upstream changes to our support_bundle_commands.conf

New features:

*  Notification Message support for BGP Graceful Restart
   (http://docs.frrouting.org/en/latest/bgp.html#clicmd-bgp-graceful-restart-notification)
*  BGP Cease Notification Subcode For BFD
   Send Hold Timer for BGP
*  RFC5424 syslog support
   (http://docs.frrouting.org/en/latest/extlog.html?#clicmd-destination-syslog-supports-rfc5424)
*  PIM passive command
   (http://docs.frrouting.org/en/latest/pim.html#clicmd-ip-pim-passive)

Detailed changelog:

* https://github.com/FRRouting/frr/releases/tag/frr-8.3

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>