### PR TITLE
systemd: let any interface satisfy systemd-networkd-wait-online

### DIFF
--- a/recipes-core/systemd/files/10-any_interface_is_enough.conf
+++ b/recipes-core/systemd/files/10-any_interface_is_enough.conf
@@ -1,0 +1,5 @@
+[Service]
+# Clear out standard setting in systemd-networkd-wait-online.service
+ExecStart=
+# Do not wait for all interfaces to be up -- one is enough
+ExecStart=/lib/systemd/systemd-networkd-wait-online --any

--- a/recipes-core/systemd/systemd.inc
+++ b/recipes-core/systemd/systemd.inc
@@ -6,6 +6,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://20-network-io.conf \
+    file://10-any_interface_is_enough.conf \
 "
 
 FILES:${PN} += "\
@@ -16,6 +17,10 @@ do_install:append() {
    # systemd-sysctl
    install -d ${D}${sysconfdir}/sysctl.d/
    install -m 0644 ${WORKDIR}/20-network-io.conf ${D}${sysconfdir}/sysctl.d/
+
+   # systemd-networkd-wait-online
+   install -d ${D}${systemd_system_unitdir}/systemd-networkd-wait-online.service.d/
+   install -m 0644 ${WORKDIR}/10-any_interface_is_enough.conf ${D}${systemd_system_unitdir}/systemd-networkd-wait-online.service.d/10-any_interface_is_enough.conf
 }
 
 USERADD_PARAM:${PN} += "--system --home /dev/null systemd-journal-gateway"


### PR DESCRIPTION
The docker service (and all other services depending on
systemd-networkd-wait-online) take 2 extra minutes to start because it
takes that long for the service waiting for all interfaces to come up to
time out.

Instead of waiting for all interfaces to come up, wait for any interface
(i.e., the management interface) to come up.