### PR TITLE
baseboxd: bump to 1.12.0

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_1.12.0.bb
+++ b/recipes-extended/baseboxd/baseboxd_1.12.0.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "19f307606bcf4c44af403cabe8b0934266098c7f"
+SRCREV = "8fd7d56bfa288e86c8d2ec48d4425cbc8f164e82"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 1.12.0:

  8fd7d56bfa28 Bump version to 1.12.0
  7bebed71f50f Merge pull request #387 from bisdn/jogo_use_mac_from_of
  5bba6f5ec1e3 tap_manager: set MAC address on created interfaces
  1c0028399755 knet_manager: set MAC address of created interfaces
  de9870de97b0 nbi: pass MAC address to port manager
  752cf5edff68 of-dpa: add MAC address to port notification
  6cdeac564f8b Merge pull request #386 from bisdn/rl_update_clang_format
  c2c3169a8876 linter.yml: disable failing linters
  cbac1dfd4b55 linter.yml: use slim linter image
  a89bbf9876f4 linter.yml: change default branch from main to master
  12e6449172aa Copy linter.yml template to enable nable super-linter
  443a6ae726b0 Update source files for clang-format

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>