### PR TITLE
Revert "frr: update to 8.3"

### DIFF
--- a/recipes-protocols/frr/clippy-native_8.2.2.bb
+++ b/recipes-protocols/frr/clippy-native_8.2.2.bb
@@ -1,8 +1,8 @@
 require frr.inc
 
-GIT_BRANCH = "stable/8.3"
-# commit hash of release tag frr-8.3
-SRCREV = "d66a1ca8da269a4de0084db45c5a9fc3352ae16c"
+GIT_BRANCH = "stable/8.2"
+# commit hash of release tag frr-8.2.2
+SRCREV = "79188bf710e92acf42fb5b9b0a2e9593a5ee9b05"
 
 PR = "r0"
 

--- a/recipes-protocols/frr/files/support_bundle_commands.conf
+++ b/recipes-protocols/frr/files/support_bundle_commands.conf
@@ -78,7 +78,6 @@ show debugging hashtable
 show running-config
 show thread cpu
 show thread poll
-show thread timers
 show daemons
 show version
 CMD_LIST_END
@@ -177,7 +176,6 @@ show ip igmp groups
 show ip igmp interface
 show ip igmp join
 show ip igmp sources
-show ip igmp statistics
 show ip pim upstream
 show ip mroute
 show ip pim join

--- a/recipes-protocols/frr/frr_8.2.2.bb
+++ b/recipes-protocols/frr/frr_8.2.2.bb
@@ -1,8 +1,8 @@
 require frr.inc
 
-GIT_BRANCH = "stable/8.3"
-# commit hash of release tag frr-8.3
-SRCREV = "d66a1ca8da269a4de0084db45c5a9fc3352ae16c"
+GIT_BRANCH = "stable/8.2"
+# commit hash of release tag frr-8.2.2
+SRCREV = "79188bf710e92acf42fb5b9b0a2e9593a5ee9b05"
 
 PR="r0"
 


### PR DESCRIPTION
* at the time of writing, frr 8.3 seems to be a lot more unstable than
  frr 8.2.2, so we are sticking with the older release for now

This reverts commit 651854ccab17f6227329c524137305f6062510ee.