### PR TITLE
set default hostname based on ONIE machine name

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -23,3 +23,6 @@ FILES:${PN}:append:x86-64 = " /lib64"
 do_install:append:x86-64() {
     ln -sf lib ${D}/lib64
 }
+
+# hostname will be set by installer
+hostname = ""

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -401,6 +401,15 @@ if [ -n "$onl_platformlib" ]; then
     ln -s "$onl_platformlib" "$bisdn_linux_mnt/usr/lib/libonlp-platform.so.1"
 fi
 
+# setup hostname
+if [ ! -f "$bisdn_linux_mnt/etc/hostname" ]; then
+    # use ONIE machine name and replace underscores with dashes, as
+    # underscores are not allowed
+    hostname="$(onie-sysinfo -m | tr '_' '-')"
+    echo $hostname > "$bisdn_linux_mnt/etc/hostname"
+    echo "127.0.1.1 $hostname" >> "$bisdn_linux_mnt/etc/hosts"
+fi
+
 # Restore the network configuration from previous installation
 if [ "${DO_RESTORE}" = true ]; then
     restore_cfg $backup_tmp_dir $bisdn_linux_mnt


### PR DESCRIPTION
Set the default hostname based on the ONIE machine name at install time
instead of hardcoded based on yocto machine name.

This makes sure that the default hostname matches the machine the image
is installed on, in case the image supports multiple machines.

This has a few side effects:

accton-as4610 will now use accton-as4610-30 or accton-as4610-54, based on
which kind it is installed on.

agema-ag5648 and agema-ag7648 will use delta-ag5648 resp. delta-ag7648,
since ONIE calls itself delta and not agema.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>