### PR TITLE
sudo: revert to old syntax for backward compatibility

### DIFF
--- a/recipes-extended/sudo/sudo_%.bbappend
+++ b/recipes-extended/sudo/sudo_%.bbappend
@@ -1,0 +1,4 @@
+do_install:append () {
+	# restore older syntax to allow going back to pre 4.8.0 images
+	sed -i 's/@includedir/#includedir/' ${D}${sysconfdir}/sudoers
+}


### PR DESCRIPTION
To allow reverting to a pre 4.7.0 image after installing 4.8.0, restore
the old include syntax which is understood by older sudos.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>