### PR TITLE
systemd-conf: avoid link flapping when DHCP sets MTU

### DIFF
--- a/recipes-core/systemd/files/wired.network
+++ b/recipes-core/systemd/files/wired.network
@@ -1,0 +1,13 @@
+[Match]
+Type=ether
+Name=en* eth*
+KernelCommandLine=!nfsroot
+KernelCommandLine=!ip
+
+[Network]
+DHCP=yes
+
+[DHCP]
+UseMTU=yes
+RouteMetric=10
+ClientIdentifier=mac

--- a/recipes-core/systemd/files/wired.network
+++ b/recipes-core/systemd/files/wired.network
@@ -6,6 +6,7 @@ KernelCommandLine=!ip
 
 [Network]
 DHCP=yes
+IgnoreCarrierLoss=1
 
 [DHCP]
 UseMTU=yes

--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,4 +1,5 @@
-do_install:prepend() {
-	# restore old match to match only on management ports
-	sed -i 's/Name=!veth\*/Name=en\* eth\*/' ${WORKDIR}/wired.network
-}
+FILESEXTRAPATHS:append := ":${THISDIR}/files"
+
+SRC_URI:append = "\
+   file://wired.network \
+"


### PR DESCRIPTION
Some network drivers need to set the link (temporarily) down to apply a
new MTU. This can cause systemd-networkd to regard the link as down, and
restart the whole process.

This affects e.g. the intel embedded NICs found in many switches.

Fix this by ignoring short link losses. See

https://github.com/systemd/systemd/issues/18738

for details.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>