### PR TITLE
installer: clean up names

### DIFF
--- a/recipes-core/images/onie-nos-installer.inc
+++ b/recipes-core/images/onie-nos-installer.inc
@@ -37,7 +37,7 @@ do_onie_bundle () {
     for platform in ${ONL_PLATFORM_SUPPORT}; do
         cp -r -L "${ONIEIMAGE_CONF_DIR}/${platform}" "${ONIEIMAGE_DIR_INSTALL}/machine"
     done
-    echo "platform=${BISDN_ONIE_PLATFORM}" >> "${ONIEIMAGE_DIR_INSTALL}/machine.conf"
+
     # Generate the payload tar file
     tar -C "${ONIEIMAGE_DIR}" -cf "${ONIEIMAGE_PAYLOAD_FILE}" "installer"
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -301,7 +301,7 @@ echo "BISDN Linux Installer"
 
 # part_size: BISDN Linux partition in MB
 part_size=6144
-fs_type="${BISDN_FS_TYPE:-ext4}"
+fs_type="ext4"
 
 # platform_check, if implemented, aborts with an error if the hardware platform
 # is not supported by our image

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -284,11 +284,11 @@ platform_install_bootloader_entry()
 }
 
 cd $(dirname $0)
-. ./machine.conf
+
 # platform.sh may override dummy functions above (e.g., platform_check)
 . ./platform.sh
 
-echo "BISDN Linux Installer: platform: $platform"
+echo "BISDN Linux Installer"
 
 # part_size: BISDN Linux partition in MB
 part_size=6144

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -283,6 +283,15 @@ platform_install_bootloader_entry()
 
 onie_platform=$(onie-sysinfo -p)
 
+# <arch>-<vendor>-<platform>-<revision>
+onl_platform="$(onie-sysinfo -p | tr '_' '-')"
+
+# <arch>-<vendor>-<platform>
+onl_baseplatform="${onl_platform%-r*}"
+
+[ -n $DEBUG ] && echo "DEBUG: onl_platform=${onl_platform}"
+[ -n $DEBUG ] && echo "DEBUG: onl_baseplatform=${onl_baseplatform}"
+
 cd $(dirname $0)
 
 # platform.sh may override dummy functions above (e.g., platform_check)
@@ -384,14 +393,6 @@ onie-support $bisdn_linux_mnt
 
 # point bootloader to kernel image (for u-boot: also copy the kernel to /boot)
 platform_install_bootloader_entry $boot_dev $bisdn_linux_part $bisdn_linux_mnt $fs_type
-
-# <arch>-<vendor>-<platform>-<revision>
-onl_platform="$(onie-sysinfo -p | tr '_' '-')"
-# <arch>-<vendor>-<platform>
-onl_baseplatform="${onl_platform%-r*}"
-
-[ -n $DEBUG ] && echo "DEBUG: onl_platform=${onl_platform}"
-[ -n $DEBUG ] && echo "DEBUG: onl_baseplatform=${onl_baseplatform}"
 
 # setup ONL platform info
 mkdir -p "$bisdn_linux_mnt/etc/onl"

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -253,8 +253,6 @@ create_bisdn_linux_msdos_partition()
 
 platform_check()
 {
-    onie_platform=$(onie-sysinfo -p)
-
     if [ ! -d "./machine/${onie_platform}" ]; then
       echo "ERROR: Unknown or unsupported platform: $onie_platform" >&2
       echo "This image only supports the following platforms:" >&2
@@ -282,6 +280,8 @@ platform_install_bootloader_entry()
 {
     /bin/true
 }
+
+onie_platform=$(onie-sysinfo -p)
 
 cd $(dirname $0)
 

--- a/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
+++ b/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
@@ -79,7 +79,7 @@ machine_fixups() {
     fi
 }
 
-hw_load() {
+create_hw_load_str() {
     local blk_dev=$1
     local bisdn_linux_part=$2
     local separator=$3

--- a/scripts/installer/u-boot-arch/install.sh
+++ b/scripts/installer/u-boot-arch/install.sh
@@ -12,7 +12,7 @@ set -e
 
 BISDN_ENABLE_NOS_MODE=1
 
-hw_load() {
+create_hw_load_str() {
     echo "cp.b $img_start \$loadaddr $img_sz"
 }
 
@@ -82,7 +82,7 @@ platform_install_bootloader_entry()
 
     # Find GUID of BISDN Linux partition and FIT configuration unit name, then
     # build a u-boot command string for loading and booting the kernel.
-    hw_load_str="$(hw_load $blk_dev $bisdn_linux_part $separator)"
+    hw_load_str="$(create_hw_load_str $blk_dev $bisdn_linux_part $separator)"
 
     echo "Updating U-Boot environment variables"
     (cat <<EOF

--- a/scripts/installer/u-boot-arch/install.sh
+++ b/scripts/installer/u-boot-arch/install.sh
@@ -87,7 +87,7 @@ platform_install_bootloader_entry()
     echo "Updating U-Boot environment variables"
     (cat <<EOF
 hw_load $hw_load_str
-copy_img echo "Loading BISDN Linux $platform image..." && run hw_load
+copy_img echo "Loading BISDN Linux image..." && run hw_load
 nos_bootcmd run copy_img && setenv bootargs quiet console=\$consoledev,\$baudrate && bootm \$loadaddr
 EOF
     ) > /tmp/env.txt

--- a/scripts/installer/u-boot-arch/install.sh
+++ b/scripts/installer/u-boot-arch/install.sh
@@ -50,8 +50,6 @@ platform_get_firmware_type()
 	echo "u-boot"
 }
 
-onie_platform="$(onie-sysinfo -p)"
-
 . ./machine/${onie_platform}/platform.conf
 
 platform_install_bootloader_entry()

--- a/scripts/installer/x86_64/install.sh
+++ b/scripts/installer/x86_64/install.sh
@@ -16,12 +16,12 @@ BISDN_ENABLE_NOS_MODE=
 # Install legacy BIOS GRUB for BISDN Linux OS
 bisdn_linux_install_grub()
 {
-    local bisdn_linux_mnt="$1"
+    local bisdn_linux_mnt_boot="$1"
     local blk_dev="$2"
 
     # Pretend we are a major distro and install GRUB into the MBR of
     # $blk_dev.
-    grub-install --boot-directory="$bisdn_linux_mnt" --recheck "$blk_dev" || {
+    grub-install --boot-directory="$bisdn_linux_mnt_boot" --recheck "$blk_dev" || {
         echo "ERROR: grub-install failed on: $blk_dev"
         exit 1
     }
@@ -30,7 +30,7 @@ bisdn_linux_install_grub()
 # Install UEFI BIOS GRUB for BISDN Linux OS
 bisdn_linux_install_uefi_grub()
 {
-    local bisdn_linux_mnt="$1"
+    local bisdn_linux_mnt_boot="$1"
     local blk_dev="$2"
 
     # Look for the EFI system partition UUID on the same block device as
@@ -53,7 +53,7 @@ bisdn_linux_install_uefi_grub()
         --no-nvram \
         --bootloader-id="$BISDN_LINUX_VOLUME_LABEL" \
         --efi-directory="/boot/efi" \
-        --boot-directory="$bisdn_linux_mnt" \
+        --boot-directory="$bisdn_linux_mnt_boot" \
         --recheck \
         "$blk_dev" > /$grub_install_log 2>&1 || {
         echo "ERROR: grub-install failed on: $blk_dev"

--- a/scripts/installer/x86_64/install.sh
+++ b/scripts/installer/x86_64/install.sh
@@ -143,8 +143,6 @@ platform_install_bootloader_entry()
     # GRUB_SERIAL_COMMAND
     # GRUB_CMDLINE_LINUX
 
-    onie_platform="$(onie-sysinfo -p)"
-
     . ./machine/${onie_platform}/platform.conf
 
     export GRUB_SERIAL_COMMAND


### PR DESCRIPTION
This PR cleans up some of the variable and function names used in the installer code. In particular, it disambiguates names that have different meanings in different contexts. It also drops variables that don't appear to be useful (anymore). 