### PR TITLE
installer: accton-as4610: handle wrong partition table type

### DIFF
--- a/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
+++ b/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
@@ -56,6 +56,20 @@ platform_detect_boot_device() {
         done
         exit 1
     fi
+
+    # ONL installer disregards the ONIE partition type and always creates an
+    # MBR/msdos partition table. This breaks various assumptions (including ONIE
+    # uninstall) so fix it up if we encounter this.
+    part_type="$(parted /dev/$blk_dev print | awk '/Partition Table/{print $3}')"
+    if [ "$part_type" != "gpt" ]; then
+        echo "WARNING: found invalid partition type $part_type on /dev/$blk_dev, erasing disk" >&2
+        # ONL will have used up all space with not enough left for converting
+        # the table to GPT. But it will also have erased the DIAG partition, so
+        # there isn't anything left to rescue, we might as well just delete
+        # everything and create a fresh partition table.
+        parted -s /dev/$blk_dev mklabel gpt
+    fi
+
     echo "/dev/$blk_dev"
 }
 


### PR DESCRIPTION
The ONL installer will force the partition table to msdos despite ONIE saying gpt in its EEPROM. This breaks various assumptions, including ONIE's uninstall scripts, which then fail to remove anything.

To work around this erase the disk and install a fresh partition table if we encounter this.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>