### PR TITLE
installer: setup management port

### DIFF
--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -424,6 +424,17 @@ if [ -n "$onl_platformlib" ]; then
     ln -s "$onl_platformlib" "$bisdn_linux_mnt/usr/lib/libonlp-platform.so.1"
 fi
 
+# Setup Management Port
+if [ -n "$MANAGEMENT_PORT_PATH" ]; then
+    (cat <<EOF
+[Match]
+Path=$MANAGEMENT_PORT_PATH
+[Link]
+Name=enp0
+EOF
+    ) > "$bisdn_linux_mnt/lib/systemd/network/90-enp.link"
+fi
+
 # setup hostname
 if [ ! -f "$bisdn_linux_mnt/etc/hostname" ]; then
     # use ONIE machine name and replace underscores with dashes, as

--- a/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
+++ b/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
@@ -6,6 +6,7 @@
 # over ride default behaviour
 
 DIAG_PART_NAME="ACCTON-DIAG"
+MANAGEMENT_PORT_PATH="platform-18022000.ethernet"
 
 platform_check() {
     local platform=$(onie-syseeprom -g 0x21)

--- a/scripts/installer/machine/x86_64-accton_as4630_54pe-r0/platform.conf
+++ b/scripts/installer/machine/x86_64-accton_as4630_54pe-r0/platform.conf
@@ -1,3 +1,4 @@
 GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200n8"
 GRUB_SERIAL_COMMAND="serial --port=0x3f8 --speed=115200 --word=8 --parity=no --stop=1"
 EXTRA_CMDLINE_LINUX="nopat intel_iommu=off"
+MANAGEMENT_PORT_PATH="pci-0000:08:00.0"


### PR DESCRIPTION
Allow supporting multiple switch models with the need to (not) rename the management port by letting the installer create the appropriate `90-enp.link` file at installation time, and then add the appropriate value to as4610 and as4630-54{p,t}e.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>