### PR TITLE
onie-tools: check for root before doing things

### DIFF
--- a/recipes-extended/onie-tools/onie-tools/onie-bisdn-rescue
+++ b/recipes-extended/onie-tools/onie-tools/onie-bisdn-rescue
@@ -27,6 +27,11 @@ while getopts "hy" o; do
   esac
 done
 
+if [[ $EUID -ne 0 ]]; then
+   echo -e "Please run this program as root\nExiting" 1>&2
+   exit 1
+fi
+
 if [ "${NEED_CONFIRM}" = true ]
 then
   read -p "Booting into ONIE rescue mode? [y/N] " yn

--- a/recipes-extended/onie-tools/onie-tools/onie-bisdn-uninstall
+++ b/recipes-extended/onie-tools/onie-tools/onie-bisdn-uninstall
@@ -24,6 +24,11 @@ while getopts "hy" o; do
   esac
 done
 
+if [[ $EUID -ne 0 ]]; then
+   echo -e "Please run this program as root\nExiting" 1>&2
+   exit 1
+fi
+
 if [ "${NEED_CONFIRM}" = true ]
 then
   read -p "Uninstalling BISDN Linux! Please confirm deletion of all files: [y/N] " yn

--- a/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
+++ b/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
@@ -36,6 +36,11 @@ while getopts "hy" o; do
   esac
 done
 
+if [[ $EUID -ne 0 ]]; then
+   echo -e "Please run this program as root\nExiting" 1>&2
+   exit 1
+fi
+
 if [[ ${NEED_CONFIRM} == false ]]; then shift;
 fi;
 


### PR DESCRIPTION
The utilities need root privileges, so we should make sure we have them before attempting anything, else we just print confusing error messages.

Fixes #124.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>