### PR TITLE
drop the linux-yocto-onl bbappend

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto-onl_5.10.bbappend
@@ -1,1 +1,0 @@
-require linux-yocto-onl_bisdn_linux.inc

--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bbappend
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bbappend
@@ -1,1 +1,0 @@
-require linux-yocto-onl_bisdn_linux.inc

--- a/recipes-kernel/linux/linux-yocto-onl_5.4.bbappend
+++ b/recipes-kernel/linux/linux-yocto-onl_5.4.bbappend
@@ -1,1 +1,0 @@
-require linux-yocto-onl_bisdn_linux.inc

--- a/recipes-kernel/linux/linux-yocto-onl_bisdn_linux.inc
+++ b/recipes-kernel/linux/linux-yocto-onl_bisdn_linux.inc
@@ -1,1 +1,0 @@
-KERNEL_FEATURES:append = " features/vrf/vrf.scc"


### PR DESCRIPTION
Drop the single KERNEL_FEATURE enabled via bbappend, since we now enable it in linux-yocto-onl directly.

Depends on https://github.com/bisdn/meta-open-network-linux/pull/95

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>