### PR TITLE
installer: create fw_env.config during installation

### DIFF
--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -435,6 +435,15 @@ EOF
     ) > "$bisdn_linux_mnt/lib/systemd/network/90-enp.link"
 fi
 
+# Setup fw_env.config
+if [ -n "$UBOOT_ENV_CONFIG" ]; then
+    (cat <<EOF
+# MTD device name       Device offset   Env. size       Flash sector size
+$UBOOT_ENV_CONFIG
+EOF
+    ) > "$bisdn_linux_mnt/etc/fw_env.config"
+fi
+
 # setup hostname
 if [ ! -f "$bisdn_linux_mnt/etc/hostname" ]; then
     # use ONIE machine name and replace underscores with dashes, as

--- a/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
+++ b/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
@@ -7,6 +7,7 @@
 
 DIAG_PART_NAME="ACCTON-DIAG"
 MANAGEMENT_PORT_PATH="platform-18022000.ethernet"
+UBOOT_ENV_CONFIG="/dev/mtd2               0x00000000      0x00002000         0x00010000"
 
 platform_check() {
     local platform=$(onie-syseeprom -g 0x21)


### PR DESCRIPTION
Instead of requiring a populated fw_env.config in the image, create one
during install time based on the platform config.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>