### PR TITLE
Add support for Accton CSP7551

### DIFF
--- a/conf/machine/accton-csp7551.conf
+++ b/conf/machine/accton-csp7551.conf
@@ -1,0 +1,62 @@
+#@TYPE: Machine
+#@NAME: accton-csp7551
+
+#@DESCRIPTION: Machine configuration for accton-csp7551 systems
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-onl"
+PREFERRED_VERSION_linux-yocto-onl ?= "5.15%"
+
+KMACHINE:accton-csp7551 = "x86_64-intel"
+KERNEL_FEATURES += "bsp/x86_64-intel"
+
+DEFAULTTUNE ?= "corei7-64"
+
+# https://git.yoctoproject.org/poky/tree/meta/conf/machine/include?h=kirkstone
+require conf/machine/include/x86/tune-corei7.inc
+require conf/machine/include/x86/x86-base.inc
+
+# https://github.com/bisdn/meta-open-network-linux/blob/main/conf/machine/include/onl.inc
+require conf/machine/include/onl.inc
+
+BISDN_SWITCH_IMAGE_EXTRA_INSTALL:remove = " \
+    baseboxd \
+    ofagent \
+    ofdpa \
+    ofdpa-grpc \
+    ofdpa-tools \
+    onl \
+    python3-ofdpa \
+"
+
+MACHINE_FEATURES += "pcbios efi"
+MACHINE_FEATURES:remove = "alsa"
+
+ONIE_VENDOR = "accton"
+ONIE_MACHINE_TYPE = "csp7551"
+
+MACHINE_EXTRA_RDEPENDS += " \
+    accton-csp7551-mods \
+    platform-onl-init \
+"
+
+# Firmware needed by qat and ice kernel modules (from poky's linux-firmware)
+MACHINE_EXTRA_RDEPENDS += " \
+    linux-firmware-ice \
+    linux-firmware-ice-license \
+    linux-firmware-qat \
+    linux-firmware-qat-license \
+"
+
+# Allow configuration of BMC via ipmitool
+MACHINE_EXTRA_RDEPENDS += " \
+    ipmitool \
+"
+
+# Development tools
+MACHINE_EXTRA_RDEPENDS += " \
+    fping \
+    iperf3 \
+    net-tools \
+    openvswitch \
+    screen \
+"

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-csp7551-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-csp7551-r0-init.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Platform init for csp7551
+
+set -o errexit -o nounset
+
+# Assuming i2c-i801 driver is not loaded (it prevents fpga_driver from
+# working properly).
+modprobe fpga_driver
+modprobe accton_i2c_cpld
+modprobe x86-64-accton-csp7551-sfp
+
+create_i2c_dev 24c64 0x57 0
+create_i2c_dev cpld_csp7551 0x62 33
+create_i2c_dev cpld_csp7551 0x64 34
+
+for i in {1..32}; do
+  create_i2c_dev csp7551_port$i 0x50 $i
+done

--- a/recipes-core/platform-onl-init/platform-onl-init_%.bbappend
+++ b/recipes-core/platform-onl-init/platform-onl-init_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://platform-x86-64-accton-csp7551-r0-init.sh \
+"

--- a/recipes-kernel/accton-csp7551-mods/accton-csp7551-mods.bb
+++ b/recipes-kernel/accton-csp7551-mods/accton-csp7551-mods.bb
@@ -1,0 +1,21 @@
+SUMMARY = "CSP 7551 platform modules"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
+
+inherit module
+
+# Platform drivers taken from:
+# https://github.com/ShoneWu/sonic-buildimage/tree/202205_fd5ddba_csp7551/platform/barefoot/sonic-platform-modules-accton/csp7551/modules
+SRC_URI = " \
+          file://Makefile \
+          file://fpga_driver.c \
+          file://accton_i2c_cpld.c \
+          file://x86-64-accton-csp7551-sfp.c \
+          file://COPYING \
+          "
+
+S = "${WORKDIR}"
+
+# Let platform init script load modules as needed
+KERNEL_MODULE_PROBECONF = "fpga_driver"
+module_conf_fpga_driver = "blacklist fpga_driver"

--- a/recipes-kernel/accton-csp7551-mods/accton-csp7551-mods.bb
+++ b/recipes-kernel/accton-csp7551-mods/accton-csp7551-mods.bb
@@ -11,6 +11,8 @@ SRC_URI = " \
           file://fpga_driver.c \
           file://accton_i2c_cpld.c \
           file://x86-64-accton-csp7551-sfp.c \
+          file://0001-accton-csp7551-sfp-update-for-Linux-6.1.patch;striplevel=4 \
+          file://0002-accton-csp7551-cpld-update-for-Linux-6.1.patch;striplevel=4 \
           file://COPYING \
           "
 

--- a/recipes-kernel/accton-csp7551-mods/files/0001-accton-csp7551-sfp-update-for-Linux-6.1.patch
+++ b/recipes-kernel/accton-csp7551-mods/files/0001-accton-csp7551-sfp-update-for-Linux-6.1.patch
@@ -1,0 +1,57 @@
+From eef0bedc46cad28fafa6a8470c16350cca0efab7 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <roger.luethi@bisdn.de>
+Date: Tue, 13 Dec 2022 14:52:28 +0100
+Subject: accton-csp7551-sfp: update for Linux 6.1
+
+This commit updates the x86-64-accton-csp7551-sfp driver for Linux 6.1.
+
+The coccinelle patch [1] failed to apply to this file. Therefore, the
+fix was created manually.
+
+[1] https://github.com/bisdn/meta-open-network-linux/blob/main/scripts/coccinelle/modules/6.1-i2c_remove_sig.cocci
+
+Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
+---
+ .../files/x86-64-accton-csp7551-sfp.c                 | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/recipes-kernel/accton-csp7551-mods/files/x86-64-accton-csp7551-sfp.c b/recipes-kernel/accton-csp7551-mods/files/x86-64-accton-csp7551-sfp.c
+index f38d231..f66f5a9 100755
+--- a/recipes-kernel/accton-csp7551-mods/files/x86-64-accton-csp7551-sfp.c
++++ b/recipes-kernel/accton-csp7551-mods/files/x86-64-accton-csp7551-sfp.c
+@@ -31,6 +31,7 @@
+ #include <linux/sysfs.h>
+ #include <linux/slab.h>
+ #include <linux/delay.h>
++#include <linux/version.h>
+ 
+ #define DRIVER_NAME     "csp7550_sfp" /* Platform dependent */
+ 
+@@ -1953,6 +1954,12 @@ static int sfp_device_remove(struct i2c_client *client)
+     return ret;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
++static void sfp_device_remove_6_1(struct i2c_client *client){
++    sfp_device_remove(client);
++}
++#endif
++
+ /* Addresses scanned
+  */
+ static const unsigned short normal_i2c[] = { I2C_CLIENT_END };
+@@ -1962,7 +1969,11 @@ static struct i2c_driver sfp_driver = {
+         .name       = DRIVER_NAME,
+     },
+     .probe          = sfp_device_probe,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
++    .remove         = sfp_device_remove_6_1,
++#else
+     .remove         = sfp_device_remove,
++#endif
+     .id_table       = sfp_device_id,
+     .address_list   = normal_i2c,
+ };
+-- 
+2.40.1
+

--- a/recipes-kernel/accton-csp7551-mods/files/0002-accton-csp7551-cpld-update-for-Linux-6.1.patch
+++ b/recipes-kernel/accton-csp7551-mods/files/0002-accton-csp7551-cpld-update-for-Linux-6.1.patch
@@ -1,0 +1,59 @@
+From cf3ae1c3c897b6d684c7422d04ea848b5509a70b Mon Sep 17 00:00:00 2001
+From: Roger Luethi <roger.luethi@bisdn.de>
+Date: Tue, 13 Dec 2022 14:42:29 +0100
+Subject: [PATCH] accton-csp7551-cpld: update for Linux 6.1
+
+This commit updates the accton_i2c_cpld driver for Linux 6.1. It was
+created by applying the coccinelle patch [1]:
+
+spatch --sp-file ./scripts/coccinelle/modules/6.1-i2c_remove_sig.cocci \
+  --in-place \
+  --dir recipes-kernel/accton-csp7551-cpld-mod/files/accton_i2c_cpld.c
+
+[1] https://github.com/bisdn/meta-open-network-linux/blob/main/scripts/coccinelle/modules/6.1-i2c_remove_sig.cocci
+
+Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
+---
+ .../accton-csp7551-mods/files/accton_i2c_cpld.c       | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/recipes-kernel/accton-csp7551-mods/files/accton_i2c_cpld.c b/recipes-kernel/accton-csp7551-mods/files/accton_i2c_cpld.c
+index 623e458..a7ea7a4 100755
+--- a/recipes-kernel/accton-csp7551-mods/files/accton_i2c_cpld.c
++++ b/recipes-kernel/accton-csp7551-mods/files/accton_i2c_cpld.c
+@@ -34,6 +34,7 @@
+ #include <linux/mutex.h>
+ #include <linux/delay.h>
+ #include <linux/list.h>
++#include <linux/version.h>
+ 
+ 
+ #define MAX_PORT_NUM				    64
+@@ -802,6 +803,11 @@ static int accton_i2c_cpld_remove(struct i2c_client *client)
+     accton_i2c_cpld_remove_client(client);
+     return 0;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
++static void accton_i2c_cpld_remove_6_1(struct i2c_client *client){
++    accton_i2c_cpld_remove(client);
++}
++#endif
+ 
+ int accton_i2c_cpld_read(u8 cpld_addr, u8 reg)
+ {
+@@ -866,7 +872,12 @@ static struct i2c_driver accton_i2c_cpld_driver = {
+         .name = "accton_i2c_cpld",
+     },
+     .probe		= accton_i2c_cpld_probe,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
++    .remove = accton_i2c_cpld_remove_6_1,
++#else
++
+     .remove	   	= accton_i2c_cpld_remove,
++#endif
+     .id_table     = accton_i2c_cpld_id,
+     .address_list = normal_i2c,
+ };
+-- 
+2.40.1
+

--- a/recipes-kernel/accton-csp7551-mods/files/COPYING
+++ b/recipes-kernel/accton-csp7551-mods/files/COPYING
@@ -1,0 +1,340 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/recipes-kernel/accton-csp7551-mods/files/Makefile
+++ b/recipes-kernel/accton-csp7551-mods/files/Makefile
@@ -1,0 +1,12 @@
+obj-m := accton_i2c_cpld.o fpga_driver.o x86-64-accton-csp7551-sfp.o
+
+SRC := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c

--- a/recipes-kernel/accton-csp7551-mods/files/accton_i2c_cpld.c
+++ b/recipes-kernel/accton-csp7551-mods/files/accton_i2c_cpld.c
@@ -1,0 +1,891 @@
+/*
+ * A hwmon driver for the accton_i2c_cpld
+ *
+ * Copyright (C) 2013 Accton Technology Corporation.
+ * Brandon Chuang <brandon_chuang@accton.com.tw>
+ *
+ * Based on ad7414.c
+ * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/err.h>
+#include <linux/slab.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/jiffies.h>
+#include <linux/mutex.h>
+#include <linux/delay.h>
+#include <linux/list.h>
+
+
+#define MAX_PORT_NUM				    64
+#define I2C_RW_RETRY_COUNT				10
+#define I2C_RW_RETRY_INTERVAL			60 /* ms */
+
+#define I2C_ADDR_CPLD1  0x62
+#define I2C_ADDR_CPLD2  0x64
+#define CPLD_ADDRS {I2C_ADDR_CPLD1, I2C_ADDR_CPLD2}
+
+#define ACCTON_I2C_DRIVER_VERSION "0.0.1"
+
+MODULE_VERSION(ACCTON_I2C_DRIVER_VERSION);
+
+/*
+ * Number of additional attribute pointers to allocate
+ * with each call to krealloc
+ */
+#define ATTR_ALLOC_SIZE	1   /*For last attribute which is NUll.*/
+
+#define NAME_SIZE		24
+#define MAX_RESP_LENGTH	48
+
+typedef ssize_t (*show_func)( struct device *dev,
+                              struct device_attribute *attr,
+                              char *buf);
+typedef ssize_t (*store_func)(struct device *dev,
+                              struct device_attribute *attr,
+                              const char *buf, size_t count);
+
+enum models {
+    CSP9550,
+    CSP7551,
+    PLAIN_CPLD,    /*No attribute but add i2c addr to the list.*/
+    NUM_MODEL
+};
+
+enum sfp_func {
+    HAS_SFP     = 1<<0 ,
+    HAS_QSFP    = 1<<1 ,
+};
+
+enum common_attrs {
+    CMN_VERSION,
+    CMN_ACCESS,
+    CMN_PRESENT_ALL,
+    CMN_MAJOR_VERSION,
+    CMN_MINOR_VERSION,
+    NUM_COMMON_ATTR
+};
+
+enum sfp_attrs {
+    SFP_PRESENT,
+    SFP_RESET,
+    SFP_LP_MODE,
+    NUM_SFP_ATTR
+};
+
+struct cpld_sensor {
+    struct cpld_sensor *next;
+    char name[NAME_SIZE+1];	/* sysfs sensor name */
+    struct device_attribute attribute;
+    bool update;		/* runtime sensor update needed */
+    int data;		/* Sensor data. Negative if there was a read error */
+
+    u8 reg;		    /* register */
+    u8 mask;		/* bit mask */
+    bool invert;	/* inverted value*/
+
+};
+
+#define to_cpld_sensor(_attr) \
+	container_of(_attr, struct cpld_sensor, attribute)
+
+struct cpld_data {
+    struct device *dev;
+    struct device *hwmon_dev;
+
+    int num_attributes;
+    struct attribute_group group;
+
+    enum models model;
+    struct cpld_sensor *sensors;
+    struct mutex update_lock;
+    bool valid;
+    unsigned long last_updated;	/* in jiffies */
+
+    int  attr_index;
+    u16  sfp_num;
+    u8   sfp_types;
+    struct model_attrs *cmn_attr;
+};
+
+struct cpld_client_node {
+    struct i2c_client *client;
+    struct list_head   list;
+};
+
+
+struct base_attrs {
+    const char *name;
+    umode_t mode;
+    show_func  get;
+    store_func set;
+};
+
+struct attrs {
+    int reg;
+    bool invert;
+    struct base_attrs *base;
+};
+
+struct model_attrs {
+    struct attrs **cmn;
+    struct attrs **portly;
+};
+
+
+static ssize_t show_bit(struct device *dev,
+                        struct device_attribute *devattr, char *buf);
+static ssize_t show_presnet_all(struct device *dev,
+                                struct device_attribute *devattr, char *buf);
+static ssize_t set_1bit(struct device *dev, struct device_attribute *da,
+                        const char *buf, size_t count);
+static ssize_t set_byte(struct device *dev, struct device_attribute *da,
+                        const char *buf, size_t count);
+static ssize_t access(struct device *dev, struct device_attribute *da,
+                      const char *buf, size_t count);
+
+int accton_i2c_cpld_read(u8 cpld_addr, u8 reg);
+int accton_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+
+
+struct base_attrs common_attrs[NUM_COMMON_ATTR] =
+{
+    [CMN_VERSION] = {"version", S_IRUGO, show_bit, NULL},
+    [CMN_ACCESS] =  {"access",  S_IWUSR, NULL, set_byte},
+    [CMN_PRESENT_ALL] = {"module_present_all", S_IRUGO, show_presnet_all, NULL},
+	[CMN_MAJOR_VERSION] = {"major_version", S_IRUGO, show_bit, NULL},		
+    [CMN_MINOR_VERSION] = {"minor_version", S_IRUGO, show_bit, NULL},
+};
+
+struct attrs csp9550_common[] = {
+    [CMN_VERSION]   = {0x01, false, &common_attrs[CMN_VERSION]},
+    [CMN_ACCESS]    = {0x00, false, &common_attrs[CMN_ACCESS]},
+    [CMN_PRESENT_ALL] = {0x30, false, &common_attrs[CMN_PRESENT_ALL]},
+};
+struct attrs csp7551_common[] = {
+    [CMN_VERSION]   = {0x01, false, &common_attrs[CMN_VERSION]},
+    [CMN_ACCESS]    = {0x00, false, &common_attrs[CMN_ACCESS]},
+    [CMN_PRESENT_ALL] = {0x60, false, &common_attrs[CMN_PRESENT_ALL]},
+	[CMN_MAJOR_VERSION]	= {0x01, false, &common_attrs[CMN_MAJOR_VERSION]},		
+    [CMN_MINOR_VERSION]   = {0x02, false, &common_attrs[CMN_MINOR_VERSION]},
+};
+struct attrs plain_common[] = {
+    [CMN_VERSION] = {0x01, false, &common_attrs[CMN_VERSION]},
+};
+
+struct base_attrs portly_attrs[] =
+{
+    [SFP_PRESENT] = {"module_present", S_IRUGO, show_bit, NULL},
+    [SFP_RESET] = {"module_reset", S_IRUGO|S_IWUSR, show_bit, set_1bit},
+};
+
+
+struct attrs csp9550_port[] = {
+    {0x70, true, &portly_attrs[SFP_PRESENT]},
+    {0x40, true, &portly_attrs[SFP_RESET]},
+};
+
+struct attrs csp7551_port[] = {
+    {0x60, true, &portly_attrs[SFP_PRESENT]},
+    {0x78, true, &portly_attrs[SFP_RESET]},
+};
+
+struct attrs *csp9550_cmn_list[] = {
+    &csp9550_common[CMN_VERSION],
+    &csp9550_common[CMN_ACCESS],
+    &csp9550_common[CMN_PRESENT_ALL],
+    NULL
+};
+
+struct attrs *csp7551_cmn_list[] = {
+    &csp7551_common[CMN_ACCESS],
+    &csp7551_common[CMN_PRESENT_ALL],    
+    &csp7551_common[CMN_MAJOR_VERSION],
+	&csp7551_common[CMN_MINOR_VERSION],
+    NULL
+};
+
+struct attrs *plain_cmn_list[] = {
+    &plain_common[CMN_VERSION],
+    NULL
+};
+
+struct attrs *csp9550_port_list[] = {
+    &csp9550_port[SFP_PRESENT],
+    &csp9550_port[SFP_RESET],
+    NULL
+};
+
+struct attrs *csp7551_port_list[] = {
+    &csp7551_port[SFP_PRESENT],
+    &csp7551_port[SFP_RESET],
+    NULL
+};
+
+struct model_attrs models_attr[NUM_MODEL] = {
+    {.cmn = csp9550_cmn_list, .portly=csp9550_port_list},
+    {.cmn = csp7551_cmn_list, .portly=csp7551_port_list},
+    {.cmn = plain_cmn_list,  .portly=NULL},
+};
+
+static LIST_HEAD(cpld_client_list);
+static struct mutex	 list_lock;
+/* Addresses scanned for accton_i2c_cpld
+ */
+static const unsigned short normal_i2c[] = { I2C_CLIENT_END };
+
+static int get_sfp_spec(int model, u16 *num, u8 *types)
+{
+    switch (model) {
+    case CSP9550:
+        *num = 56;
+        *types = HAS_QSFP|HAS_SFP;
+		break; 
+    case CSP7551:
+        *num = 32;
+        *types = HAS_QSFP;
+		break; 
+    default:
+        *types = 0;
+        *num = 0;
+        break;        
+    }
+
+    return 0;
+}
+
+static int get_present_reg(int model, u8 port, u8 *cpld_addr, u8 *reg, u8 *num)
+{
+    u8 cpld_address[] = CPLD_ADDRS;
+    
+    switch (model) {
+    case CSP9550:
+        if (port < 48) {
+            *cpld_addr = cpld_address[1 + port/24];
+            *reg = 0x09 + (port%24)/8;
+            *num = 8;
+        }
+        else
+        {
+            *reg = 0x18;
+            *num = 4;
+            *cpld_addr = ( port < 52)? cpld_address[1]: cpld_address[2];
+        }
+		break;
+    case CSP7551:
+        *cpld_addr = cpld_address[port/16];
+		if ((port>=0 && port <=7)||(port>=16 && port <=23))
+		{
+        	*reg = 0x60;
+        }
+		else
+		{			
+        	*reg = 0x61;
+		}
+		*num = 8;
+		break;
+    default:
+        return -EINVAL;      
+    }
+}
+        
+
+/*Assume the bits for ports are listed in-a-row.*/
+static int get_reg_bit(u8 reg_start, int port,
+                       u8 *reg ,u8 *mask)
+{
+    *reg = reg_start + ((port)/8);
+    *mask = 1 << ((port)%8);
+
+    return 0;
+}
+
+static int cpld_write_internal(
+    struct i2c_client *client, u8 reg, u8 value)
+{
+    int status = 0, retry = I2C_RW_RETRY_COUNT;
+
+    while (retry) {
+        status = i2c_smbus_write_byte_data(client, reg, value);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    return status;
+}
+
+static int cpld_read_internal(struct i2c_client *client, u8 reg)
+{
+    int status = 0, retry = I2C_RW_RETRY_COUNT;
+
+    while (retry) {
+        status = i2c_smbus_read_byte_data(client, reg);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    return status;
+}
+
+
+/*Turn a numberic array into string with " " between each element.
+ * e.g., {0x11, 0x33, 0xff, 0xf1}  => "11 33 ff f1" 
+ */
+static ssize_t array_stringify(char *buf, u8 *input, size_t size) {
+
+    int i;
+    char t[MAX_RESP_LENGTH+1];
+
+    buf[0] = '\0';
+    for (i = 0; i < size; i++) {
+        snprintf(t, MAX_RESP_LENGTH, "%x ", input[i]);
+        strncat(buf, t, MAX_RESP_LENGTH);
+    }
+
+    if (strlen(buf) > 0)
+        buf[strlen(buf)-1] = '\0'; /*Remove tailing blank*/
+
+    return snprintf(buf, MAX_RESP_LENGTH, "%s\n", buf);
+}
+
+static ssize_t show_presnet_all_distinct(struct device *dev,
+                                struct device_attribute *devattr, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct cpld_data *data = i2c_get_clientdata(client);
+    u8 i=0, value, reg;
+    u8 cpld_addr, num;
+    u8 _value[8];    
+    u64 *values = (u64 *)_value;
+    
+    values = 0;
+    mutex_lock(&data->update_lock);
+    while(i < data->sfp_num)
+    {
+        get_present_reg(data->model, i, &cpld_addr, &reg, &num);
+        if(cpld_addr == client->addr)
+           value = cpld_read_internal(client, reg);    
+        else           
+           value = accton_i2c_cpld_read(cpld_addr, reg);
+           
+        if (unlikely(value < 0)) {
+            goto exit;
+        }        
+
+        *values |= (value&((1<<(num))-1)) << i;
+        i += num; 
+    }
+    mutex_unlock(&data->update_lock);
+
+    *values = cpu_to_le64(*values);
+    return array_stringify(buf, _value, i);
+exit:
+    mutex_unlock(&data->update_lock);
+    return value;    
+}
+
+static ssize_t show_presnet_all(struct device *dev,
+                                struct device_attribute *devattr, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct cpld_data *data = i2c_get_clientdata(client);
+    struct cpld_sensor *sensor = to_cpld_sensor(devattr);
+    u8 i, values[MAX_RESP_LENGTH/8];
+
+    if (sensor->reg < 0) {
+        return show_presnet_all_distinct(dev, devattr, buf);
+    }
+    
+    mutex_lock(&data->update_lock);
+    for (i = 0; i < ((data->sfp_num+7)/16); i++) {
+        values[i] = cpld_read_internal(client, sensor->reg + i);
+        if (unlikely(values[i] < 0)) {
+            goto exit;
+        }
+    }
+    mutex_unlock(&data->update_lock);
+    return array_stringify(buf, values, i);
+    
+exit:
+    mutex_unlock(&data->update_lock);
+    return values[i];
+}
+
+static ssize_t show_bit(struct device *dev,
+                        struct device_attribute *devattr, char *buf)
+{
+    int value;
+    struct i2c_client *client = to_i2c_client(dev);
+    struct cpld_data *data = i2c_get_clientdata(client);
+    struct cpld_sensor *sensor = to_cpld_sensor(devattr);
+
+    mutex_lock(&data->update_lock);
+    value = cpld_read_internal(client, sensor->reg);
+    value = value & sensor->mask;
+    if (sensor->invert)
+        value = !value;
+    mutex_unlock(&data->update_lock);
+
+    return snprintf(buf, PAGE_SIZE, "%x\n", value);
+}
+
+static ssize_t set_1bit(struct device *dev, struct device_attribute *devattr,
+                        const char *buf, size_t count)
+{
+    long is_reset;
+    int value, status;
+    struct i2c_client *client = to_i2c_client(dev);
+    struct cpld_data *data = i2c_get_clientdata(client);
+    struct cpld_sensor *sensor = to_cpld_sensor(devattr);
+    u8 cpld_bit, reg;
+
+    status = kstrtol(buf, 10, &is_reset);
+    if (status) {
+        return status;
+    }
+    reg = sensor->reg;
+    cpld_bit = sensor->mask;
+    mutex_lock(&data->update_lock);
+    value = cpld_read_internal(client, reg);
+    if (unlikely(status < 0)) {
+        goto exit;
+    }
+
+    if (sensor->invert)
+        is_reset = !is_reset;
+
+    if (is_reset) {
+        value |= cpld_bit;
+    }
+    else {
+        value &= ~cpld_bit;
+    }
+
+    status = cpld_write_internal(client, reg, value);
+    if (unlikely(status < 0)) {
+        goto exit;
+    }
+    mutex_unlock(&data->update_lock);
+    return count;
+
+exit:
+    mutex_unlock(&data->update_lock);
+    return status;
+}
+
+static ssize_t set_byte(struct device *dev, struct device_attribute *da,
+                        const char *buf, size_t count)
+{
+    return access(dev, da, buf,  count);
+}
+
+static ssize_t access(struct device *dev, struct device_attribute *da,
+                      const char *buf, size_t count)
+{
+    int status;
+    u32 addr, val;
+    struct i2c_client *client = to_i2c_client(dev);
+    struct cpld_data *data = i2c_get_clientdata(client);
+
+    if (sscanf(buf, "0x%x 0x%x", &addr, &val) != 2) {
+        return -EINVAL;
+    }
+
+    if (addr > 0xFF || val > 0xFF) {
+        return -EINVAL;
+    }
+
+    mutex_lock(&data->update_lock);
+    status = cpld_write_internal(client, addr, val);
+    if (unlikely(status < 0)) {
+        goto exit;
+    }
+    mutex_unlock(&data->update_lock);
+    return count;
+
+exit:
+    mutex_unlock(&data->update_lock);
+    return status;
+}
+
+static void accton_i2c_cpld_add_client(struct i2c_client *client)
+{
+    struct cpld_client_node *node =
+        kzalloc(sizeof(struct cpld_client_node), GFP_KERNEL);
+
+    if (!node) {
+        dev_dbg(&client->dev, "Can't allocate cpld_client_node (0x%x)\n",
+                client->addr);
+        return;
+    }
+    node->client = client;
+
+    mutex_lock(&list_lock);
+    list_add(&node->list, &cpld_client_list);
+    mutex_unlock(&list_lock);
+}
+
+static void accton_i2c_cpld_remove_client(struct i2c_client *client)
+{
+    struct list_head		*list_node = NULL;
+    struct cpld_client_node *cpld_node = NULL;
+    int found = 0;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &cpld_client_list)
+    {
+        cpld_node = list_entry(list_node, struct cpld_client_node, list);
+
+        if (cpld_node->client == client) {
+            found = 1;
+            break;
+        }
+    }
+
+    if (found) {
+        list_del(list_node);
+        kfree(cpld_node);
+    }
+
+    mutex_unlock(&list_lock);
+}
+
+static int cpld_add_attribute(struct cpld_data *data, struct attribute *attr)
+{
+    int new_max_attrs = ++data->num_attributes + ATTR_ALLOC_SIZE;
+    void *new_attrs = krealloc(data->group.attrs,
+                               new_max_attrs * sizeof(void *),
+                               GFP_KERNEL);
+    if (!new_attrs)
+        return -ENOMEM;
+    data->group.attrs = new_attrs;
+
+
+    data->group.attrs[data->num_attributes-1] = attr;
+    data->group.attrs[data->num_attributes] = NULL;
+
+    return 0;
+}
+
+static void cpld_dev_attr_init(struct device_attribute *dev_attr,
+                               const char *name, umode_t mode,
+                               show_func show, store_func store)
+{
+    sysfs_attr_init(&dev_attr->attr);
+    dev_attr->attr.name = name;
+    dev_attr->attr.mode = mode;
+    dev_attr->show = show;
+    dev_attr->store = store;
+}
+
+static struct cpld_sensor * add_sensor(struct cpld_data *data,
+                                       const char *name,
+                                       u8 reg, u8 mask, bool invert,
+                                       bool update, umode_t mode,
+                                       show_func  get,  store_func set)
+{
+    struct cpld_sensor *sensor;
+    struct device_attribute *a;
+
+    sensor = devm_kzalloc(data->dev, sizeof(*sensor), GFP_KERNEL);
+    if (!sensor)
+        return NULL;
+    a = &sensor->attribute;
+
+    snprintf(sensor->name, sizeof(sensor->name), name);
+    sensor->reg = reg;
+    sensor->mask = mask;
+    sensor->update = update;
+    sensor->invert = invert;
+    cpld_dev_attr_init(a, sensor->name,
+                       mode,
+                       get, set);
+
+    if (cpld_add_attribute(data, &a->attr))
+        return NULL;
+
+    sensor->next = data->sensors;
+    data->sensors = sensor;
+
+    return sensor;
+}
+
+static int add_attributes_cmn(struct cpld_data *data, struct attrs **cmn)
+{
+    u8 reg, i ;
+    bool invert;
+    struct attrs *a;
+    struct base_attrs *b;
+
+    if (NULL == cmn)
+        return -1;
+
+    for (i = 0; cmn[i]; i++)
+    {
+        a = cmn[i];
+
+        reg = a->reg;
+        invert = a->invert;
+
+        b = a->base;
+        if (NULL == b)
+            break;
+
+        if (add_sensor(data, b->name,
+                       reg, 0xff, invert,
+                       true, b->mode,
+                       b->get, b->set) == NULL)
+        {
+            return -ENOMEM;
+        }
+    }
+    return 0;
+}
+
+static int add_attributes_portly(struct cpld_data *data, struct attrs **pa)
+{
+	struct i2c_client *client = to_i2c_client(data->dev);
+    char name[NAME_SIZE+1];
+    int i, j;
+    u8 reg, mask, invert;
+    struct attrs *a;
+    struct base_attrs *b;
+
+    if (NULL == pa)
+        return -1;
+
+
+    for (i = 0; pa[i]; i++) {
+        a = pa[i];
+
+        invert = a->invert;
+        b = a->base;
+        if (b == NULL)
+            break;
+
+        for (j = 0; j < data->sfp_num/2; j++)
+        {
+        
+            snprintf(name, NAME_SIZE, "%s_%d", b->name, (client->addr==I2C_ADDR_CPLD1)? j+1:j+17);
+            get_reg_bit(a->reg, j, &reg, &mask);
+
+            if (add_sensor(data, name, reg, mask, invert,
+                           true, b->mode,  b->get,  b->set) == NULL)
+            {
+                return -ENOMEM;
+            }
+        }
+    }
+    return 0;
+}
+
+static int add_attributes(struct i2c_client *client,
+                          struct cpld_data *data)
+{
+    struct model_attrs *m = data->cmn_attr;
+
+    if (m == NULL)
+        return -EINVAL;
+
+    /* Common attributes.*/
+    add_attributes_cmn(data, m->cmn);
+
+    /* Port-wise attributes.*/
+    add_attributes_portly(data, m->portly);
+
+    return 0;
+}
+
+static int accton_i2c_cpld_probe(struct i2c_client *client,
+                                 const struct i2c_device_id *dev_id)
+{
+    int status;
+    struct cpld_data *data = NULL;
+    struct device *dev = &client->dev;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_dbg(dev, "i2c_check_functionality failed (0x%x)\n", client->addr);
+        return -EIO;
+    }
+    printk(KERN_INFO "i2c_check_functionality ok (0x%x)\n", client->addr);
+
+    data = devm_kzalloc(dev, sizeof(*data), GFP_KERNEL);
+    if (!data) {
+        return -ENOMEM;
+    }
+
+    data->model = dev_id->driver_data;
+    data->cmn_attr = &models_attr[data->model];
+    get_sfp_spec(data->model, &data->sfp_num, &data->sfp_types);
+
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+    data->dev = dev;
+    dev_info(dev, "chip found\n");
+
+    status = add_attributes(client, data);
+    if (status) {
+        goto out_kfree;
+    }
+
+    /*
+     * If there are no attributes, something is wrong.
+     * Bail out instead of trying to register nothing.
+     */
+    if (!data->num_attributes) {
+        dev_err(dev, "No attributes found\n");
+        status = -ENODEV;
+        goto out_kfree;
+    }
+
+    /* Register sysfs hooks */
+    status = sysfs_create_group(&client->dev.kobj, &data->group);
+    if (status) {
+        goto out_kfree;
+    }
+
+    data->hwmon_dev = hwmon_device_register(&client->dev);
+    if (IS_ERR(data->hwmon_dev)) {
+        status = PTR_ERR(data->hwmon_dev);
+        goto exit_remove;
+    }
+
+    accton_i2c_cpld_add_client(client);
+    dev_info(dev, "%s: cpld '%s'\n", dev_name(data->hwmon_dev), client->name);
+
+    return 0;
+exit_remove:
+    sysfs_remove_group(&client->dev.kobj, &data->group);
+out_kfree:
+    kfree(data->group.attrs);
+    return status;
+
+}
+
+static int accton_i2c_cpld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+
+    hwmon_device_unregister(data->hwmon_dev);
+    sysfs_remove_group(&client->dev.kobj, &data->group);
+    kfree(data->group.attrs);
+    accton_i2c_cpld_remove_client(client);
+    return 0;
+}
+
+int accton_i2c_cpld_read(u8 cpld_addr, u8 reg)
+{
+    struct list_head   *list_node = NULL;
+    struct cpld_client_node *cpld_node = NULL;
+    int ret = -EPERM;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &cpld_client_list)
+    {
+        cpld_node = list_entry(list_node, struct cpld_client_node, list);
+
+        if (cpld_node->client->addr == cpld_addr) {
+            ret = i2c_smbus_read_byte_data(cpld_node->client, reg);
+            break;
+        }
+    }
+
+    mutex_unlock(&list_lock);
+
+    return ret;
+}
+EXPORT_SYMBOL(accton_i2c_cpld_read);
+
+int accton_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value)
+{
+    struct list_head   *list_node = NULL;
+    struct cpld_client_node *cpld_node = NULL;
+    int ret = -EIO;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &cpld_client_list)
+    {
+        cpld_node = list_entry(list_node, struct cpld_client_node, list);
+
+        if (cpld_node->client->addr == cpld_addr) {
+            ret = i2c_smbus_write_byte_data(cpld_node->client, reg, value);
+            break;
+        }
+    }
+
+    mutex_unlock(&list_lock);
+
+    return ret;
+}
+EXPORT_SYMBOL(accton_i2c_cpld_write);
+
+
+static const struct i2c_device_id accton_i2c_cpld_id[] = {
+    { "cpld_csp9550", CSP9550},
+    { "cpld_csp7551", CSP7551},
+    { "cpld_plain", PLAIN_CPLD},
+    { },
+};
+MODULE_DEVICE_TABLE(i2c, accton_i2c_cpld_id);
+
+static struct i2c_driver accton_i2c_cpld_driver = {
+    .class        = I2C_CLASS_HWMON,
+    .driver = {
+        .name = "accton_i2c_cpld",
+    },
+    .probe		= accton_i2c_cpld_probe,
+    .remove	   	= accton_i2c_cpld_remove,
+    .id_table     = accton_i2c_cpld_id,
+    .address_list = normal_i2c,
+};
+
+
+static int __init accton_i2c_cpld_init(void)
+{
+    mutex_init(&list_lock);
+    return i2c_add_driver(&accton_i2c_cpld_driver);
+}
+
+static void __exit accton_i2c_cpld_exit(void)
+{
+    i2c_del_driver(&accton_i2c_cpld_driver);
+}
+
+module_init(accton_i2c_cpld_init);
+module_exit(accton_i2c_cpld_exit);
+
+MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+MODULE_DESCRIPTION("accton_i2c_cpld driver");
+MODULE_LICENSE("GPL");

--- a/recipes-kernel/accton-csp7551-mods/files/fpga_driver.c
+++ b/recipes-kernel/accton-csp7551-mods/files/fpga_driver.c
@@ -1,0 +1,1423 @@
+#include <linux/module.h> /*
+                            => module_init()
+                            => module_exit()
+                            => MODULE_LICENSE()
+                            => MODULE_VERSION()
+                            => MODULE_AUTHOR()
+                            => struct module
+                          */
+#include <linux/init.h>  /*
+                            => typedef int (*initcall_t)(void);
+                                 Note: the 'initcall_t' function returns 0 when succeed.
+                                       In the Linux kernel, error codes are negative numbers
+                                       belonging to the set defined in <linux/errno.h>.
+                            => typedef void (*exitcall_t)(void);
+                            => __init
+                            => __exit
+                         */
+#include <linux/moduleparam.h>  /*
+                                  => moduleparam()
+                                */
+#include <linux/types.h>  /*
+                             => dev_t  (u32)
+                          */
+#include <linux/kdev_t.h>  /*
+                              => MAJOR()
+                              => MINOR()
+                           */
+#include <linux/fs.h>  /*
+                          => register_chrdev_region()
+                          => unregister_chrdev_region()
+                          => alloc_chrdev_region()
+                          => struct file_operations
+                          => struct file
+                          => struct inode
+                          => unsigned int imajor()
+                          => unsigned int iminor()
+                       */
+#include <linux/cdev.h>  /*
+                            => struct cdev
+                         */
+#include <linux/string.h>  /*
+                              => void *memset()
+                           */
+#include <linux/slab.h>  /*
+                            => void kfree()
+                          */
+#include <linux/device.h>  /*
+                              => class_create()
+                              => device_create()
+                           */
+#include <linux/pci.h>
+#include <linux/interrupt.h>
+#include <linux/cdev.h>  /*
+                            => void cdev_init()
+                         */
+#include <linux/uaccess.h> /*
+                              => access_ok()
+                           */
+#include <asm/current.h>  /*
+                              => current 
+                          */
+#include <linux/semaphore.h> /*
+                                => struct semaphore
+                             */
+#include <linux/wait.h> /*
+                           => struct wait_queue_head_t
+                           => init_waitqueue_head()
+                        */
+#include <linux/fcntl.h> /*
+                           => O_NONBLOCK
+                         */
+#include <linux/delay.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/version.h> 
+
+#define I2C_DEBUG(...)
+//#define I2C_DEBUG(...) printk(KERN_ALERT __VA_ARGS__)
+#define ERROR_DEBUG(...) printk(KERN_ALERT __VA_ARGS__)
+
+// Uncomment this for support interrupt
+//#define INTERRUPT_SUPPORT
+
+#define FPGA_DRIVER_VERSION "0.0.f"
+
+MODULE_LICENSE("GPL");
+MODULE_VERSION(FPGA_DRIVER_VERSION);
+MODULE_AUTHOR("Will Chen (will_chen@accton.com)");
+
+#define FPGA_DEV_NAME       "fpga"
+#define FPGA_CLASS_NAME     "fpga_class"
+#define FPGA_DRIVER_NAME    "fpgaio"
+#define FPGA_REGION_NAME    "fpga_register"
+#define FPGA_SMBUS_NAME     "Accton_FPGA_SMBus_"
+#define BAR0                0
+
+#if 1 // Please copy the following definition into the c files if you want to use fpga_access
+#define MAX_BUFF_SIZE   128
+#define MAX_EEPROM_SIZE 256
+
+/* file_operations: ioctl */
+struct fpga_access {
+    /* input */
+    unsigned char   addr;       /* 0x0 - 0x7F */
+    unsigned char   offset;
+    unsigned char   length;
+    unsigned char   channel;
+    /* intput output buff */
+    unsigned char   buff[MAX_BUFF_SIZE];
+};
+
+#define FPGA_MAGIC      0xA7
+#define FPGA_IO_CMD     0x10
+#define FPGA_SPI_IO     0x11
+#define FPGA_LOCK_CMD   0xEE
+#define FPGA_UNLOCK_CMD 0xDD
+
+#define FPGA_READ       _IOR(FPGA_MAGIC, FPGA_IO_CMD,     struct fpga_access)
+#define FPGA_WRITE      _IOW(FPGA_MAGIC, FPGA_IO_CMD,     struct fpga_access)
+#define FPGA_LOCK       _IOW(FPGA_MAGIC, FPGA_LOCK_CMD,   struct fpga_access)
+#define FPGA_UNLOCK     _IOW(FPGA_MAGIC, FPGA_UNLOCK_CMD, struct fpga_access)
+#define FPGA_SPI_READ   _IOR(FPGA_MAGIC, FPGA_SPI_IO,     struct fpga_access)
+#define FPGA_SPI_WRITE  _IOW(FPGA_MAGIC, FPGA_SPI_IO,     struct fpga_access)
+
+#endif // Please copy the above definition into the c files if you want to use fpga_access
+
+/* FPGA Bus control parameters */
+static unsigned int max_retry_time = 20;
+static unsigned int delay_ack = 50;
+static unsigned int delay_tip = 26;
+static unsigned int delay_busy = 10;
+static unsigned int fpga_dev_count = 1;
+//module_param(fpga_dev_count, uint, S_IRUSR|S_IWUSR);
+module_param(max_retry_time, uint, S_IRUGO);
+MODULE_PARM_DESC(max_retry_time, "Max retry times to wait TIP/ACK (20 by default)");
+module_param(delay_ack, uint, S_IRUGO);
+MODULE_PARM_DESC(delay_ack, "Delay time before the next time to check ACK bit (50 us by default)");
+module_param(delay_tip, uint, S_IRUGO);
+MODULE_PARM_DESC(delay_tip, "Delay time before the next time to check TIP bit (26 us by default)");
+module_param(delay_busy, uint, S_IRUGO);
+MODULE_PARM_DESC(delay_busy, "Delay time before the next time to check BUSY bit (10 us by default)");
+
+
+#define MAX_CHANNEL             34
+#define FPGA_SLEEP(X)           usleep_range((X*8/10), X)
+
+#define I2C_PRESCALE_LOW_OFFSET     0x0400  // PRESCALE registers, PRERlo
+#define I2C_PRESCALE_HIGH_OFFSET    0x0404  // PRESCALE registers, PRERhi
+#define I2C_CONTROLLER_OFFSET       0x0408  // Control Register, CTR
+#define I2C_TRANSMIT_RECEIVE_OFFSET 0x040C  // Transmit Register, TXR
+#define I2C_COMMAND_STATUS_OFFSET   0x0410  // Command Register CR/Status Registesr, SR
+
+#define PRER_LO_DEFAULT             0x007f
+#define PRER_HI_DEFAULT             0x0000
+#define CONTROL_DISABLE             0x0000
+#define CONTROL_ENABLE              0x0080
+#define COMMAND_START_WRITE         0x0090
+#define COMMAND_ENABLE_WRITE        0x0010
+#define COMMAND_READ                0x0020
+#define COMMAND_ACK_STOP_READ       0x0068
+#define COMMAND_STOP                0x0040
+#define COMMAND_STOP_WRITE          0x0050
+#define BUSY_BIT                    0x40
+#define TIP_BIT                     0x2
+#define ACK_BIT                     0x80
+#define SET_TXR_WRITE(x)            (x &= ~(1UL))
+#define SET_TXR_READ(x)             (x |= (1UL))
+
+struct fpga_pci_device {
+    char                *name;
+    dev_t               fpga_dev_number;
+    struct class        *fpga_class;
+    struct device       *fpga_udev;
+    struct cdev         fpga_cdev;
+    resource_size_t     start;
+    resource_size_t     len;
+    void                *fpga_base;
+    int                 irq_vec_count;
+    unsigned int        irq;
+    int                 pci_enabled;
+    int                 pci_region_requested;
+    int                 cdev_added;
+    struct semaphore    sem[MAX_CHANNEL];
+    struct spinlock     fpga_pcie_lock;
+    struct i2c_adapter  adapter[MAX_CHANNEL];
+};
+
+#define ACCESS_ONCE(x) (*(volatile typeof(x) *)&(x))
+
+#define FPGA_ACCESS(cmd) \
+    do { \
+        unsigned long flags; \
+        spin_lock_irqsave(&(fpga_pci_dev->fpga_pcie_lock), flags); \
+        cmd \
+        spin_unlock_irqrestore(&(fpga_pci_dev->fpga_pcie_lock), flags); \
+    }while(0);
+
+/* 10ee:7021 */
+static struct pci_device_id fpga_id_table[] = { \
+    { 
+        0x10ee,     /* Vendor ID */
+        0x7021,     /* Device ID */
+        PCI_ANY_ID, /* Sub-vendor ID */
+        PCI_ANY_ID, /* Sub-device ID */
+        0,          /* Class */
+        0,          /* Class mask */
+        0,          /* Driver data */
+    },
+    {0,},
+};
+
+static int fpga_smbus_check_busy(struct fpga_pci_device *fpga_pci_dev, unsigned int i2c_cmd_stat_addr, unsigned int *i2c_stat)
+{
+    unsigned int retry_times = 0;
+    unsigned int transaction_delay = delay_busy;
+
+    for(retry_times = 0; retry_times < max_retry_time; retry_times++)
+    {
+        FPGA_SLEEP(transaction_delay);
+        FPGA_ACCESS(*i2c_stat = ACCESS_ONCE(*((unsigned int *)(fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)));)
+        I2C_DEBUG("[check_busy] i2c_stat:%x\n", *i2c_stat);
+        if((*i2c_stat & BUSY_BIT) == 0)
+        {
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int fpga_smbus_check_tip(struct fpga_pci_device *fpga_pci_dev, unsigned int i2c_cmd_stat_addr, unsigned int *i2c_stat)
+{
+    unsigned int retry_times = 0;
+    unsigned int transaction_delay = delay_tip;
+
+    for(retry_times = 0; retry_times < max_retry_time; retry_times++)
+    {
+        FPGA_SLEEP(transaction_delay);
+        FPGA_ACCESS(*i2c_stat = ACCESS_ONCE(*((unsigned int *)(fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)));)
+        I2C_DEBUG("[check_tip] i2c_stat:%x\n", *i2c_stat);
+        if((*i2c_stat & TIP_BIT) == 0)
+        {
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int fpga_smbus_check_ack(struct fpga_pci_device *fpga_pci_dev, unsigned int i2c_cmd_stat_addr, unsigned int *i2c_stat)
+{
+    unsigned int retry_times = 0;
+    unsigned int ack_transaction_delay = delay_ack;
+
+    for(retry_times = 0; retry_times < max_retry_time; retry_times++)
+    {
+        I2C_DEBUG("[check_ack] i2c_stat:%x\n", *i2c_stat);
+        if((*i2c_stat & ACK_BIT) == 0)
+        {
+            return 0;
+        }
+        FPGA_SLEEP(ack_transaction_delay);
+        FPGA_ACCESS(*i2c_stat = ACCESS_ONCE(*((unsigned int *)(fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)));)
+    }
+
+    if(*i2c_stat & ACK_BIT)
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+int fpga_smbus_read(struct fpga_pci_device *fpga_pci_dev, 
+    unsigned char channel, unsigned char addr, unsigned char offset, unsigned char length,
+    unsigned char *data)
+{
+    int retval = 0;
+    int stop_step = 0;
+    unsigned int i2c_txr_addr = 0, i2c_cmd_stat_addr = 0;
+    unsigned int i2c_txr_data = 0, i2c_cmd_stat_data = 0;
+    unsigned int i2c_stat = 0;
+    unsigned char byte_to_rw = 0, temp_offset = 0;
+    unsigned char buff[MAX_BUFF_SIZE];
+
+    I2C_DEBUG("[%s] READ: %x \n", __func__, data->byte);
+
+    if (addr > 0x7F || channel > MAX_CHANNEL)
+    {
+        return(-EINVAL);
+    }
+
+    retval = down_interruptible(&(fpga_pci_dev->sem[channel]));
+    if (retval)
+    {
+        return(-ERESTARTSYS);
+    }
+
+    i2c_txr_addr = I2C_TRANSMIT_RECEIVE_OFFSET + channel*0x20;
+    i2c_cmd_stat_addr = I2C_COMMAND_STATUS_OFFSET + channel*0x20;
+
+    /*
+    1. Set the Transmit Register TXR with a value of Slave address + Write bit.
+    2. Set the Command Register CR to 8'h90 to enable the START and WRITE. This starts the transmission on the I2C bus.
+    3. Check the Transfer In Progress (TIP) bit of the Status Register, SR, to make sure the command is done.
+       Check the Received Acknowledge (RxACK) bit of the Status Register, SR, to make sure I2C slave has ACK.
+    4. Set TRX with the slave memory address, where the data is to be read from.
+    5. Set CR with 8'h10 to enable a WRITE to send to the slave memory address.
+    6. Check the TIP bit of SR, to make sure the command is done.
+       Check the Received Acknowledge (RxACK) bit of the Status Register, SR, to make sure I2C slave has ACK.
+    7. Set TRX with a value of Slave address + READ bit.
+    8. Set CR with the 8'h90 to enable the START (repeated START in this case) and WRITE the value in TXR to the slave device.
+    9. Check the TIP bit of SR, to make sure the command is done.
+       Check the Received Acknowledge (RxACK) bit of the Status Register, SR, to make sure I2C slave has ACK.
+    10. Set CR with 8'h20 to issue a READ command and then an ACK command. This enables the reading of data from the slave device.
+    11. Check the TIP bit of SR, to make sure the command is done.
+    12. Repeat steps 10 and 11 to continue to read data from the slave device.
+    13. When the Master is ready to stop reading from the Slave, set CR to 8'h28. This will read the last byte of data and then issue a NACK.
+        Check the TIP bit of SR, to make sure the command is done.
+    */
+
+    // 1. Set the Transmit Register TXR with a value of Slave address + Write bit.
+    i2c_txr_data = (addr) << 1;
+    SET_TXR_WRITE(i2c_txr_data);
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_txr_addr)) = i2c_txr_data;)
+    I2C_DEBUG("[1] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+
+    // 2. Set the Command Register CR to 8'h90 to enable the START and WRITE. This starts the transmission on the I2C bus.
+    i2c_cmd_stat_data = COMMAND_START_WRITE;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    I2C_DEBUG("[2] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+    // 3. Check the Transfer In Progress (TIP) bit of the Status Register, SR, to make sure the command is done.
+    if(fpga_smbus_check_tip(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 3;
+        goto device_busy;
+    }
+
+    // Check the ACK bit of the Status Registesr, SR, to make sure ACK is received.
+    if(fpga_smbus_check_ack(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 3;
+        goto no_ack_response;
+    }
+
+    // 4. Set TRX with the slave memory address, where the data is to be read from.
+    i2c_txr_data = offset;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_txr_addr)) = i2c_txr_data;)
+    I2C_DEBUG("[4] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+
+    // 5. Set CR with 8'h10 to enable a WRITE to send to the slave memory address.
+    i2c_cmd_stat_data = COMMAND_ENABLE_WRITE;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    I2C_DEBUG("[5] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+    // 6. Check the TIP bit of SR, to make sure the command is done.
+    if(fpga_smbus_check_tip(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 6;
+        goto device_busy;
+    }
+
+    // Check the ACK bit of the Status Registesr, SR, to make sure ACK is received.
+    if(fpga_smbus_check_ack(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 6;
+        goto no_ack_response;
+    }
+
+    // 7. Set TRX with a value of Slave address + READ bit.
+    i2c_txr_data = (addr) << 1;
+    SET_TXR_READ(i2c_txr_data);
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_txr_addr)) = i2c_txr_data;)
+    I2C_DEBUG("[7] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+
+    // 8. Set CR with the 8'h90 to enable the START (repeated START in this case) and WRITE the value in TXR to the slave device.
+    i2c_cmd_stat_data = COMMAND_START_WRITE;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    I2C_DEBUG("[8] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+    // 9. Check the TIP bit of SR, to make sure the command is done.
+    if(fpga_smbus_check_tip(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 9;
+        goto device_busy;
+    }
+
+    // Check the ACK bit of the Status Registesr, SR, to make sure ACK is received.
+    if(fpga_smbus_check_ack(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 9;
+        goto no_ack_response;
+    }
+
+    // 12. Repeat steps 10 and 11 to continue to read data from the slave device.
+    byte_to_rw = length;
+    temp_offset = 0;
+    while(byte_to_rw > 1)
+    {
+        // 10. Set CR with 8'h20 to issue a READ command and then an ACK command. This enables the reading of data from the slave device.
+        i2c_cmd_stat_data = COMMAND_READ;
+        FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+        I2C_DEBUG("[10] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+        
+        // 11. Check the TIP bit of SR, to make sure the command is done.
+        if(fpga_smbus_check_tip(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+        {
+            stop_step = 11;
+            goto device_busy;
+        }
+
+        // Check the ACK bit of the Status Registesr, SR, to make sure ACK is received.
+        if(fpga_smbus_check_ack(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+        {
+            stop_step = 11;
+            goto no_ack_response;
+        }
+
+        // Get TXR with 8-bit data from the slave device.
+        FPGA_ACCESS(i2c_txr_data = ACCESS_ONCE(*((unsigned int *)(fpga_pci_dev->fpga_base + i2c_txr_addr)));)
+        buff[temp_offset] = i2c_txr_data;
+        I2C_DEBUG("[11-2] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+
+        byte_to_rw--;
+        temp_offset++;
+    }
+
+    // 13.When the Master is ready to stop reading from the Slave, set CR to 8'h28. This will read the last byte of data and then issue a NACK.
+    i2c_cmd_stat_data = COMMAND_ACK_STOP_READ;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    I2C_DEBUG("[13-1] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+    // Check the BUSY bit of SR, to make sure the command is done.
+    if(fpga_smbus_check_busy(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 13;
+        goto device_busy;
+    }
+
+    if(byte_to_rw)
+    {
+        // Get the last byte from TXR with 8-bit data from the slave device.
+        FPGA_ACCESS(i2c_txr_data = ACCESS_ONCE(*((unsigned int *)(fpga_pci_dev->fpga_base + i2c_txr_addr)));)
+        buff[temp_offset] = i2c_txr_data;
+        I2C_DEBUG("[13-3] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+    }
+
+    memcpy(data, buff, length);
+
+    up(&(fpga_pci_dev->sem[channel]));
+    return(0);
+
+device_busy:
+    printk(KERN_NOTICE "device_busy, write failed, channel:%d addr:0x%x, length:0x%x, offset:0x%x, stop_step:%d, i2c_stat:0x%x.\n", channel, addr, length, offset, stop_step, i2c_stat);
+
+    // Re-initailize BUS.
+    // 0. Disable the core by writing 8'h00 to the Control Register, CTR.
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_CONTROLLER_OFFSET + channel*0x20)) = CONTROL_DISABLE;)
+    // 1. Program the clock PRESCALE registers, PRERlo and PRERhi, with the desired value. This value is determined by the clock frequency and the speed of the I2C bus.
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_PRESCALE_LOW_OFFSET + channel*0x20)) = PRER_LO_DEFAULT;)
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_PRESCALE_HIGH_OFFSET + channel*0x20)) = PRER_HI_DEFAULT;)
+    // 2. Enable the core by writing 8'h80 to the Control Register, CTR.
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_CONTROLLER_OFFSET + channel*0x20)) = CONTROL_ENABLE;)
+    FPGA_SLEEP(500);
+
+    //Set CR to 8'h40 to issue a STOP command to avoid error.
+    i2c_cmd_stat_data = COMMAND_STOP;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    // Check the BUSY bit of SR, to make sure STOP is sent.
+    if(fpga_smbus_check_busy(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        printk(KERN_NOTICE "device_busy, fail to issue STOP, i2c_stat:0x%x.\n", i2c_stat);
+    }
+
+    printk(KERN_NOTICE "device_busy, read failed, channel:%d addr:0x%x, length:0x%x, offset:0x%x, stop_step:%d, i2c_stat:0x%x.\n", channel, addr, length, offset, stop_step, i2c_stat);
+    up(&(fpga_pci_dev->sem[channel]));
+    return (-EBUSY);
+
+no_ack_response:
+    //Set CR to 8'h40 to issue a STOP command to avoid error.
+    i2c_cmd_stat_data = COMMAND_STOP;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+
+    printk(KERN_NOTICE "no_ack_response, read failed, channel:%d addr:0x%x, length:0x%x, offset:0x%x, stop_step:%d, i2c_stat:0x%x.\n", channel, addr, length, offset, stop_step, i2c_stat);
+
+    // Check the BUSY bit of SR, to make sure STOP is sent.
+    if(fpga_smbus_check_busy(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 14;
+        goto device_busy;
+    }
+
+    up(&(fpga_pci_dev->sem[channel]));
+    return (-ETIMEDOUT);
+}
+
+
+int fpga_smbus_write(struct fpga_pci_device *fpga_pci_dev, 
+    unsigned char channel, unsigned char addr, unsigned char offset, unsigned char length,
+    unsigned char *data)
+{
+    int retval = 0;
+    int stop_step = 0;
+    unsigned int i2c_txr_addr = 0, i2c_cmd_stat_addr = 0;
+    unsigned int i2c_txr_data = 0, i2c_cmd_stat_data = 0;
+    unsigned int i2c_stat = 0;
+    unsigned char byte_to_rw = 0, temp_offset = 0;
+    unsigned char buff[MAX_BUFF_SIZE];
+
+    I2C_DEBUG("[%s] WRITE\n", __func__);
+
+    if (addr > 0x7F || channel > MAX_CHANNEL)
+    {
+        return(-EINVAL);
+    }
+
+    retval = down_interruptible(&(fpga_pci_dev->sem[channel]));
+    if (retval)
+    {
+        return(-ERESTARTSYS);
+    }
+
+    i2c_txr_addr = I2C_TRANSMIT_RECEIVE_OFFSET + channel*0x20;
+    i2c_cmd_stat_addr = I2C_COMMAND_STATUS_OFFSET + channel*0x20;
+    memcpy(buff, data, length);
+
+    /*
+    1. Set the Transmit Register TXR with a value of Slave address + Write bit.
+    2. Set the Command Register CR to 8'h90 to enable the START and WRITE. This starts the transmission on the I2C bus.
+    3. Check the Transfer In Progress (TIP) bit of the Status Register, SR, to make sure the command is done.
+       Check the Received Acknowledge (RxACK) bit of the Status Register, SR, to make sure I2C slave has ACK.
+    4. Set TXR with a slave memory address for the data to be written to.
+    5. Set CR with 8'h10 to enable a WRITE to send to the slave memory address.
+    6. Check the TIP bit of SR, to make sure the command is done.
+       Check the Received Acknowledge (RxACK) bit of the Status Register, SR, to make sure I2C slave has ACK.
+    7. Set TXR with 8-bit data for the slave device.
+    8. Set CR to 8'h10 to enable a WRITE to send data.
+    9. Check the TIP bit of SR, to make sure the command is done.
+       Check the Received Acknowledge (RxACK) bit of the Status Register, SR, to make sure I2C slave has ACK.
+    10. Repeat steps 7 to 9 to continue to send data to the slave device.
+    11. Set CR to 8'h40 to then issue a STOP command.
+        Check the TIP bit of SR, to make sure the command is done.
+    */
+
+    // 1. Set the Transmit Register TXR with a value of Slave address + Write bit.
+    i2c_txr_data = (addr) << 1;
+    SET_TXR_WRITE(i2c_txr_data);
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_txr_addr)) = i2c_txr_data;)
+    I2C_DEBUG("[1] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+
+    // 2. Set the Command Register CR to 8'h90 to enable the START and WRITE. This starts the transmission on the I2C bus.
+    i2c_cmd_stat_data = COMMAND_START_WRITE;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    I2C_DEBUG("[2] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+    // 3. Check the Transfer In Progress (TIP) bit of the Status Registesr, SR, to make sure the command is done.
+    if(fpga_smbus_check_tip(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 3;
+        goto device_busy;
+    }
+
+    // Check the ACK bit of the Status Registesr, SR, to make sure ACK is received.
+    if(fpga_smbus_check_ack(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 3;
+        goto no_ack_response;
+    }
+
+    // 4. Set TXR with a slave memory address for the data to be written to.
+    i2c_txr_data = offset;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_txr_addr)) = i2c_txr_data;)
+    I2C_DEBUG("[4] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+
+    // 5. Set CR with 8'h10 to enable a WRITE to send to the slave memory address.
+    i2c_cmd_stat_data = COMMAND_ENABLE_WRITE;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    I2C_DEBUG("[5] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+    // 6. Check the TIP bit of SR, to make sure the command is done.
+    if(fpga_smbus_check_tip(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 6;
+        goto device_busy;
+    }
+
+    // Check the ACK bit of the Status Registesr, SR, to make sure ACK is received.
+    if(fpga_smbus_check_ack(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 6;
+        goto no_ack_response;
+    }
+
+    // 10. Repeat steps 7 to 9 to continue to send data to the slave device.
+    byte_to_rw = length;
+    temp_offset = 0;
+    while(byte_to_rw > 0)
+    {
+        // 7. Set TXR with 8-bit data for the slave device.
+        i2c_txr_data = buff[temp_offset];
+        FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_txr_addr)) = i2c_txr_data;)
+        I2C_DEBUG("[7] i2c_txr_addr:%x i2c_txr_data:%x\n", i2c_txr_addr, i2c_txr_data);
+
+        // 8. Set CR to 8'h10 to enable a WRITE to send data.
+        i2c_cmd_stat_data = COMMAND_ENABLE_WRITE;
+        FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+        I2C_DEBUG("[8] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+        // 9. Check the TIP bit of SR, to make sure the command is done.
+        if(fpga_smbus_check_tip(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+        {
+            stop_step = 9;
+            goto device_busy;
+        }
+
+        // Check the ACK bit of the Status Registesr, SR, to make sure ACK is received.
+        if(fpga_smbus_check_ack(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+        {
+            stop_step = 9;
+            goto no_ack_response;
+        }
+
+        byte_to_rw--;
+        temp_offset++;
+    }
+
+    // 11. Set CR to 8'h40 to issue a STOP command.
+    i2c_cmd_stat_data = COMMAND_STOP;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    I2C_DEBUG("[12] i2c_cmd_stat_addr:%x i2c_cmd_stat_data:%x\n", i2c_cmd_stat_addr, i2c_cmd_stat_data);
+
+    // Check the BUSY bit of SR, to make sure STOP is sent.
+    if(fpga_smbus_check_busy(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 12;
+        goto device_busy;
+    }
+
+    up(&(fpga_pci_dev->sem[channel]));
+    return(0);
+
+device_busy:
+    printk(KERN_NOTICE "device_busy, write failed, channel:%d addr:0x%x, length:0x%x, offset:0x%x, stop_step:%d, i2c_stat:0x%x.\n", channel, addr, length, offset, stop_step, i2c_stat);
+
+    // Re-initailize BUS.
+    // 0. Disable the core by writing 8'h00 to the Control Register, CTR.
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_CONTROLLER_OFFSET + channel*0x20)) = CONTROL_DISABLE;)
+    // 1. Program the clock PRESCALE registers, PRERlo and PRERhi, with the desired value. This value is determined by the clock frequency and the speed of the I2C bus.
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_PRESCALE_LOW_OFFSET + channel*0x20)) = PRER_LO_DEFAULT;)
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_PRESCALE_HIGH_OFFSET + channel*0x20)) = PRER_HI_DEFAULT;)
+    // 2. Enable the core by writing 8'h80 to the Control Register, CTR.
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + I2C_CONTROLLER_OFFSET + channel*0x20)) = CONTROL_ENABLE;)
+    FPGA_SLEEP(500);
+
+    //Set CR to 8'h40 to issue a STOP command to avoid error.
+    i2c_cmd_stat_data = COMMAND_STOP;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+    // Check the BUSY bit of SR, to make sure STOP is sent.
+    if(fpga_smbus_check_busy(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        printk(KERN_NOTICE "device_busy, fail to issue STOP, i2c_stat:0x%x.\n", i2c_stat);
+    }
+
+    up(&(fpga_pci_dev->sem[channel]));
+    return (-EBUSY);
+
+no_ack_response:
+    //Set CR to 8'h40 to issue a STOP command to avoid error.
+    i2c_cmd_stat_data = COMMAND_STOP;
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_cmd_stat_addr)) = i2c_cmd_stat_data;)
+
+    printk(KERN_NOTICE "no_ack_response, write failed, channel:%d addr:0x%x, length:0x%x, offset:0x%x, stop_step:%d, i2c_stat:0x%x.\n", channel, addr, length, offset, stop_step, i2c_stat);
+
+    // Check the BUSY bit of SR, to make sure STOP is sent.
+    if(fpga_smbus_check_busy(fpga_pci_dev, i2c_cmd_stat_addr, &i2c_stat))
+    {
+        stop_step = 13;
+        goto device_busy;
+    }
+
+    up(&(fpga_pci_dev->sem[channel]));
+    return (-ETIMEDOUT);
+}
+
+
+static u32 fpga_smbus_func(struct i2c_adapter *adapter)
+{
+	return I2C_FUNC_SMBUS_QUICK | I2C_FUNC_SMBUS_BYTE |
+	       I2C_FUNC_SMBUS_BYTE_DATA | I2C_FUNC_SMBUS_WORD_DATA;
+}
+
+
+/* Return negative errno on error. */
+static s32 fpga_smbus_access(struct i2c_adapter *adap, u16 addr,
+		       unsigned short flags, char read_write, u8 command,
+		       int size, union i2c_smbus_data *data)
+{
+    struct fpga_pci_device *fpga_pci_dev;
+    int retval = 0;
+    unsigned char length = 0, channel = 0;
+    char cha_num_str[3] = {0};
+
+    I2C_DEBUG("[%s]name:%s addr:0x%x flags:0x%x read_write:0x%x command:0x%x size:0x%x\n", 
+        __func__, adap->name, addr, flags, read_write, command, size);
+
+    switch(size)
+    {
+        case I2C_SMBUS_BYTE:
+            length = 1;
+            break;
+        case I2C_SMBUS_BYTE_DATA:
+            length = 1;
+            break;
+        case I2C_SMBUS_WORD_DATA:
+            length = 2;
+            break;
+        case I2C_SMBUS_BLOCK_DATA:
+            length = 32;
+            break;
+        case I2C_SMBUS_I2C_BLOCK_DATA:
+            length = 32;
+            break;
+        case I2C_SMBUS_QUICK:
+            length = 0;
+            break;
+        default:
+            length = 1;
+            break;
+    }
+
+    memcpy(cha_num_str, (adap->name+18), 2);
+    retval = kstrtou8(cha_num_str, 10, &channel);
+    if(retval == 0)
+    {
+        I2C_DEBUG("channel:%d \n", channel);
+    }
+    else
+    {
+        I2C_DEBUG("Error:%d, channel:%s \n", retval, cha_num_str);
+    }
+
+    fpga_pci_dev = i2c_get_adapdata(adap);
+    if(fpga_pci_dev == NULL)
+    {
+        return(-EINVAL);
+    }
+
+    if(length > 32+2)
+    {
+        return(-EINVAL);
+    }
+
+    if(I2C_SMBUS_READ == read_write)
+    {
+        retval = fpga_smbus_read(fpga_pci_dev, channel, addr, command, length, (unsigned char *)data);
+    }
+    else if(I2C_SMBUS_WRITE == read_write)
+    {
+        retval = fpga_smbus_write(fpga_pci_dev, channel, addr, command, length, (unsigned char *)data);
+    }
+
+    return retval;
+}
+
+
+static const struct i2c_algorithm smbus_algorithm = {
+	.smbus_xfer	= fpga_smbus_access,
+	.functionality	= fpga_smbus_func,
+};
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+static pci_ers_result_t fpga_error_detected(struct pci_dev *pdev, enum pci_channel_state error)
+#else
+static pci_ers_result_t fpga_error_detected(struct pci_dev *pdev, pci_channel_state_t error)
+#endif
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    return PCI_ERS_RESULT_CAN_RECOVER;
+}
+
+static pci_ers_result_t fpga_mmio_enabled(struct pci_dev *pdev)
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    return PCI_ERS_RESULT_CAN_RECOVER;
+}
+
+static pci_ers_result_t fpga_slot_reset(struct pci_dev *pdev)
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    return PCI_ERS_RESULT_CAN_RECOVER;
+}
+
+#if 0
+static void fpga_reset_notify(struct pci_dev *pdev, bool prepare)
+{
+  I2C_DEBUG( "[%s]\n", __func__);
+  return;
+}
+#endif
+
+static void fpga_resume(struct pci_dev *pdev)
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    return;
+}
+
+///* PCI bus error event callbacks */
+//struct pci_error_handlers {
+//        /* PCI bus error detected on this device */
+//        pci_ers_result_t (*error_detected)(struct pci_dev *dev,
+//                                           enum pci_channel_state error);
+//
+//        /* MMIO has been re-enabled, but not DMA */
+//        pci_ers_result_t (*mmio_enabled)(struct pci_dev *dev);
+//
+//        /* PCI slot has been reset */
+//        pci_ers_result_t (*slot_reset)(struct pci_dev *dev);
+//
+//        /* PCI function reset prepare or completed */
+//        void (*reset_notify)(struct pci_dev *dev, bool prepare);
+//
+//        /* Device driver may resume normal operations */
+//        void (*resume)(struct pci_dev *dev);
+//};
+static const struct pci_error_handlers fpga_error_handlers = {
+    .error_detected = fpga_error_detected,
+    .mmio_enabled   = fpga_mmio_enabled,
+    .slot_reset     = fpga_slot_reset,
+    //.reset_notify   = fpga_reset_notify,
+    .resume         = fpga_resume,
+};
+
+static int fpga_open(struct inode *inode, struct file *filp)
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    filp->private_data = (void *) container_of(inode->i_cdev, struct fpga_pci_device, fpga_cdev);
+
+    return(0);
+}
+
+static int fpga_release(struct inode *inode, struct file *filp)
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    return(0);
+}
+
+ssize_t fpga_read(struct file *filp, char __user *user_data, size_t size, loff_t *offset)
+{
+    struct fpga_pci_device *fpga_pci_dev = NULL;
+
+    fpga_pci_dev = (struct fpga_pci_device *) filp->private_data;
+    I2C_DEBUG( "[%s] %s\n", __func__, fpga_pci_dev->name);
+
+    return(0);
+}
+
+ssize_t fpga_write(struct file *filp, const char __user *user_data, size_t size, loff_t *offset)
+{
+    struct fpga_pci_device *fpga_pci_dev = NULL;
+
+    fpga_pci_dev = (struct fpga_pci_device *) filp->private_data;
+    I2C_DEBUG( "[%s] %s\n", __func__, fpga_pci_dev->name);
+
+    return(size);
+}
+
+long fpga_init_smbus(struct fpga_pci_device *fpga_pci_dev)
+{
+    unsigned int i2c_ctrl_addr = 0;
+    unsigned int i2c_ctrl_data = 0;
+    unsigned int i2c_pre_low_addr = 0, i2c_pre_high_addr = 0;
+    unsigned int i2c_pre_low_data = 0, i2c_pre_high_data = 0;
+    int temp_channel = 0;
+
+    for(temp_channel = 0; temp_channel<MAX_CHANNEL; temp_channel++)
+    {
+        /*
+        1. Program the clock PRESCALE registers, PRERlo and PRERhi, with the desired value. This value is determined by the clock frequency and the speed of the I2C bus.
+        2. Enable the core by writing 8'h80 to the Control Register, CTR.
+        */
+        i2c_pre_low_addr = I2C_PRESCALE_LOW_OFFSET + temp_channel*0x20;
+        i2c_pre_high_addr = I2C_PRESCALE_HIGH_OFFSET + temp_channel*0x20;
+        i2c_ctrl_addr = I2C_CONTROLLER_OFFSET + temp_channel*0x20;
+
+        // 1. Program the clock PRESCALE registers, PRERlo and PRERhi, with the desired value. This value is determined by the clock frequency and the speed of the I2C bus.
+        i2c_pre_low_data = PRER_LO_DEFAULT;
+        FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_pre_low_addr)) = i2c_pre_low_data;)
+        I2C_DEBUG( "[pre1-1] i2c_pre_low_addr:%x %x\n", i2c_pre_low_addr, i2c_pre_low_addr);
+        
+        i2c_pre_high_data = PRER_HI_DEFAULT;
+        FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_pre_high_addr)) = i2c_pre_high_data;)
+        I2C_DEBUG( "[pre1-2] i2c_pre_high_addr:%x %x\n", i2c_pre_high_addr, i2c_pre_high_addr);
+        
+        // 2. Enable the core by writing 8'h80 to the Control Register, CTR.
+        i2c_ctrl_data= CONTROL_ENABLE;
+        FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + i2c_ctrl_addr)) = i2c_ctrl_data;)
+        I2C_DEBUG( "[pre1] i2c_ctrl_addr:%x %x\n", i2c_ctrl_addr, i2c_ctrl_addr);
+    }
+
+    return 0;
+}
+
+long fpga_mask_all_intr(struct fpga_pci_device *fpga_pci_dev)
+{
+    // 1. Mask all I2C Module Interrupt (0x38)
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + 0x38)) = 0xFFFFFFFF;)
+
+    // 2. Mask CPLD Interrupt Mask
+    FPGA_ACCESS(*((unsigned int *) (fpga_pci_dev->fpga_base + 0x3C)) = 0x00000007;)
+
+    return 0;
+}
+
+long fpga_ioctl(struct file *filp, unsigned int cmd, unsigned long user_addr)
+{
+    struct fpga_pci_device *fpga_pci_dev = NULL;
+    struct fpga_access acc = {0};
+    int retval = 0;
+    unsigned short spi_offset = 0;
+
+    if (cmd == FPGA_READ) 
+    {
+        I2C_DEBUG( "[%s] READ\n", __func__);
+        fpga_pci_dev = (struct fpga_pci_device *) filp->private_data;
+
+        if (!access_ok(
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+		VERIFY_READ, 
+#endif
+		user_addr, _IOC_SIZE(cmd)))
+        {
+          //I2C_DEBUG( "[%s] Access NOT OK\n", __func__);
+          return(-EINVAL);
+        }
+
+        retval = copy_from_user((void *) &acc, (const void *) user_addr, sizeof(struct fpga_access));
+        if (retval)
+        {
+            return(-EFAULT);
+        }
+
+        if (acc.length + acc.offset > MAX_EEPROM_SIZE)
+        {
+            return(-EINVAL);
+        }
+
+        retval = fpga_smbus_read(fpga_pci_dev, acc.channel, acc.addr, acc.offset, acc.length, acc.buff);
+        if(retval != 0)
+        {
+            return retval;
+        }
+
+        retval = copy_to_user((void *) user_addr, (const void *) &acc, sizeof(struct fpga_access));
+        if (retval)
+        {
+            return(-EFAULT);
+        }
+
+        return(0);
+    }
+    else if (cmd == FPGA_WRITE) 
+    {
+        fpga_pci_dev = (struct fpga_pci_device *) filp->private_data;
+
+        if (!access_ok(
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+		VERIFY_WRITE, 
+#endif
+        user_addr, _IOC_SIZE(cmd)))
+        {
+            //I2C_DEBUG( "[%s] Access NOT OK\n", __func__);
+            return(-EINVAL);
+        }
+
+        retval = copy_from_user((void *) &acc, (const void *) user_addr, sizeof(struct fpga_access));
+        if (retval)
+        {
+            return(-EFAULT);
+        }
+
+        if (acc.length + acc.offset > MAX_EEPROM_SIZE)
+        {
+            return(-EINVAL);
+        }
+
+        retval = fpga_smbus_write(fpga_pci_dev, acc.channel, acc.addr, acc.offset, acc.length, acc.buff);
+        if(retval != 0)
+        {
+            return retval;
+        }
+
+        return(0);
+    }
+    else if (cmd == FPGA_LOCK)
+    {
+        return(0);
+    }
+    else if (cmd == FPGA_UNLOCK)
+    {
+        return(0);
+    }
+    else if (cmd == FPGA_SPI_READ || cmd == FPGA_SPI_WRITE)
+    {
+        fpga_pci_dev = (struct fpga_pci_device *) filp->private_data;
+
+        if (!access_ok(
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+		VERIFY_WRITE, 
+#endif 
+        user_addr, _IOC_SIZE(cmd)))
+        {
+            //I2C_DEBUG( "[%s] Access NOT OK\n", __func__);
+            return(-EINVAL);
+        }
+
+        retval = copy_from_user((void *) &acc, (const void *) user_addr, sizeof(struct fpga_access));
+        if (retval)
+        {
+            return(-EFAULT);
+        }
+
+        //retval = down_interruptible(&(fpga_pci_dev->sem));
+        if (retval)
+        {
+            return(-ERESTARTSYS);
+        }
+        spi_offset = (acc.buff[0]<<8) + acc.buff[1];
+        if (cmd == FPGA_SPI_READ)
+        {
+            FPGA_ACCESS(acc.buff[2] = ACCESS_ONCE(*((unsigned char *)(fpga_pci_dev->fpga_base + spi_offset)));)
+        }
+        else if (cmd == FPGA_SPI_WRITE)
+        {
+            FPGA_ACCESS(*((unsigned char *) (fpga_pci_dev->fpga_base + spi_offset)) = acc.buff[2];)
+        }
+        retval = copy_to_user((void *) user_addr, (const void *) &acc, sizeof(struct fpga_access));
+        //up(&(fpga_pci_dev->sem[0]));
+
+        return(0);
+    }
+    else
+    {
+        ERROR_DEBUG( "[%s] Unknown command\n", __func__);
+        return(-EINVAL);
+    }
+}
+
+#ifdef INTERRUPT_SUPPORT
+static irqreturn_t fpga_intr_msi(int irq, void *data)
+{
+    static int count=0;
+    //struct fpga_pci_device *fpga_pci_dev = (struct fpga_pci_device *) data;
+
+    // Disable interrupt first
+    disable_irq_nosync(irq);
+
+    // This function is only HW test.
+    // The user should implement relative function for interrupt handle.
+
+    // Enable interrupt
+    enable_irq(irq);
+
+    printk(KERN_INFO "MSI irq:%d, count=%d\n", irq, count);
+    count++;
+
+    return IRQ_HANDLED;
+}
+#endif
+
+/* Extracted from <linux/fs.h>
+int (*open) (struct inode *, struct file *);
+int (*release) (struct inode *, struct file *);
+
+ssize_t (*read) (struct file *, char __user *, size_t, loff_t *);
+  Leaving this pointer NULL will return -EINVAL
+
+ssize_t (*write) (struct file *, const char __user *, size_t, loff_t *);
+  Leaving this pointer NULL will return -EINVAL
+
+loff_t (*llseek) (struct file *, loff_t, int);
+  Leaving this pointer NULL will cause un-predictable behavior
+
+long (*unlocked_ioctl) (struct file *, unsigned int, unsigned long);
+  If the device doesn't provide an ioctl method, the system call returns
+  an error for any request that isn't predefined (-ENOTTY, "No such ioctl for device").
+
+unsigned int (*poll) (struct file *, struct poll_table_struct *);
+  If a driver leaves its poll method NULL, the device is assumed to
+  be both readable and writable without blocking.
+*/
+static struct file_operations fpga_fops = {
+    .owner          = THIS_MODULE,
+    .open           = fpga_open,
+    .read           = fpga_read,
+    .write          = fpga_write,
+    .unlocked_ioctl = fpga_ioctl,
+    .release        = fpga_release,
+};
+
+
+//struct pci_driver {
+//        struct list_head        node;
+//        const char              *name;
+//        const struct pci_device_id *id_table;   /* Must be non-NULL for probe to be called */
+//        int  (*probe)(struct pci_dev *dev, const struct pci_device_id *id);     /* New device inserted */
+//        void (*remove)(struct pci_dev *dev);    /* Device removed (NULL if not a hot-plug capable driver) */
+//        int  (*suspend)(struct pci_dev *dev, pm_message_t state);       /* Device suspended */
+//        int  (*suspend_late)(struct pci_dev *dev, pm_message_t state);
+//        int  (*resume_early)(struct pci_dev *dev);
+//        int  (*resume)(struct pci_dev *dev);    /* Device woken up */
+//        void (*shutdown)(struct pci_dev *dev);
+//        int  (*sriov_configure)(struct pci_dev *dev, int num_vfs); /* On PF */
+//        const struct pci_error_handlers *err_handler;
+//        const struct attribute_group **groups;
+//        struct device_driver    driver;
+//        struct pci_dynids       dynids;
+//};
+
+static int fpga_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+{
+    int retval = 0;
+    struct fpga_pci_device *fpga_pci_dev = NULL;
+    int smbus_temp_num;
+
+    fpga_pci_dev = (struct fpga_pci_device *) kzalloc(sizeof(struct fpga_pci_device), GFP_KERNEL);
+    if (!fpga_pci_dev)
+    {
+        ERROR_DEBUG( "[%s] Fail to alloc fpga_pci_dev memory\n", __func__);
+        retval = -ENOMEM;
+        goto fail_to_alloc_fpga_pci_dev;
+    }
+    pci_set_drvdata(pdev, (void *) fpga_pci_dev);
+
+    fpga_pci_dev->name = "Accton FPGA";
+
+    /* Alloc device number(s) */
+    retval = alloc_chrdev_region(&(fpga_pci_dev->fpga_dev_number), 0, fpga_dev_count, FPGA_DEV_NAME);
+    if (retval)
+    {
+        ERROR_DEBUG( "[%s] Fail to alloc fpga_dev_number %d\n", __func__, fpga_pci_dev->fpga_dev_number);
+        goto fail_to_alloc_dev_number;
+    }
+
+    /* Create FPGA class */
+    fpga_pci_dev->fpga_class = class_create(THIS_MODULE, FPGA_CLASS_NAME);
+    if (IS_ERR(fpga_pci_dev->fpga_class))
+    {
+        ERROR_DEBUG( "[%s] Fail to create %s [fpga_class: %p]\n", __func__, FPGA_CLASS_NAME, fpga_pci_dev->fpga_class);
+        retval = PTR_ERR(fpga_pci_dev->fpga_class);
+        goto fail_to_create_fpga_class;
+    }
+    I2C_DEBUG( "[%s] fpga_class created\n", __func__);
+
+    /* Create FPGA udev device */
+    fpga_pci_dev->fpga_udev =
+        device_create(fpga_pci_dev->fpga_class, NULL, fpga_pci_dev->fpga_dev_number, NULL, FPGA_DEV_NAME);
+
+    if (IS_ERR(fpga_pci_dev->fpga_udev))
+    {
+        ERROR_DEBUG( "[%s] Fail to create fpga_udev\n", __func__);
+        retval = PTR_ERR(fpga_pci_dev->fpga_udev);
+        goto fail_to_create_fpga_udev;
+    }
+    I2C_DEBUG( "[%s] fpga_udev created\n", __func__);
+
+    /* PCIe config */
+    retval = pci_enable_device(pdev);
+    if (retval)
+    {
+        ERROR_DEBUG( "[%s] Fail to enable PCIe device\n", __func__);
+        goto fail_to_enable_pci_device;
+    }
+    fpga_pci_dev->pci_enabled = 1;
+
+    fpga_pci_dev->start = pci_resource_start(pdev, BAR0);
+    I2C_DEBUG( "[%s] Get PCI resource address 0x%llx\n", __func__, fpga_pci_dev->start);
+
+    fpga_pci_dev->len = pci_resource_len(pdev, BAR0);
+    I2C_DEBUG( "[%s] Get PCI resource length %llu\n", __func__, fpga_pci_dev->len);
+
+    retval = pci_request_region(pdev, BAR0, FPGA_REGION_NAME);
+    if (retval)
+    {
+        ERROR_DEBUG( "[%s] Fail to request PCI resource region\n", __func__);
+        goto fail_to_request_pci_region;
+    }
+    fpga_pci_dev->pci_region_requested = 1;
+
+    /* Remap to virtual memory address */
+    fpga_pci_dev->fpga_base = pci_iomap(pdev, BAR0, fpga_pci_dev->len);
+    if (!fpga_pci_dev->fpga_base) {
+        ERROR_DEBUG( "[%s] Fail to remap PCI resource address\n", __func__);
+        retval = -ENODEV;
+        goto fail_to_remap_pci_resource;
+    }
+    else 
+    {
+        I2C_DEBUG( "[%s] Remap PCI resource address 0x%p\n", __func__, fpga_pci_dev->fpga_base);
+    }
+
+    /* Init these items before interrupt is enabled */
+    for(smbus_temp_num = 0; smbus_temp_num < MAX_CHANNEL; smbus_temp_num++)
+    {
+        sema_init(&(fpga_pci_dev->sem[smbus_temp_num]), 1);
+    }
+    spin_lock_init(&(fpga_pci_dev->fpga_pcie_lock));
+
+    pci_set_master(pdev);
+
+    // Mask all interrupt by default.
+    fpga_mask_all_intr(fpga_pci_dev);
+#ifdef INTERRUPT_SUPPORT
+    /* Register interrupt */
+    retval = pci_alloc_irq_vectors(pdev, 1, 1, PCI_IRQ_MSI);
+    if (retval > 0)
+    {
+        fpga_pci_dev->irq_vec_count = retval;
+        printk(KERN_INFO "[%s] PCI irq vector count %d IRQ number: %u\n", __func__, retval, pdev->irq);
+    }
+    else
+    {
+        printk(KERN_ALERT "[%s] Fail to alloc PCI irq vectors\n", __func__);
+        goto fail_to_alloc_irq_vectors;
+    }
+
+    retval = request_irq(pci_irq_vector(pdev, 0), fpga_intr_msi, 0, "FPGA MSI", (void *) fpga_pci_dev);
+    if (retval < 0) {
+        printk(KERN_ALERT "[%s] Fail to request irq\n", __func__);
+        goto fail_to_request_irq;
+      } else {
+        printk(KERN_INFO "[%s] Request irq no. %d\n", __func__, pdev->irq);
+        fpga_pci_dev->irq = pdev->irq;
+    }
+#endif
+
+    /* Configure character device */
+    cdev_init(&(fpga_pci_dev->fpga_cdev), &fpga_fops);
+    fpga_pci_dev->fpga_cdev.owner = THIS_MODULE;
+    retval = cdev_add(&(fpga_pci_dev->fpga_cdev), fpga_pci_dev->fpga_dev_number, fpga_dev_count);
+    if (retval)
+    {
+        goto fail_to_add_fpga_cdev;
+    }
+    fpga_pci_dev->cdev_added = 1;
+
+    /* Init I2C adap for FPGA SMbus */
+    for(smbus_temp_num = 0; smbus_temp_num < MAX_CHANNEL; smbus_temp_num++)
+    {
+        i2c_set_adapdata(&fpga_pci_dev->adapter[smbus_temp_num], fpga_pci_dev);
+        fpga_pci_dev->adapter[smbus_temp_num].owner = THIS_MODULE;
+        fpga_pci_dev->adapter[smbus_temp_num].class = I2C_CLASS_HWMON | I2C_CLASS_SPD;;
+        fpga_pci_dev->adapter[smbus_temp_num].algo = &smbus_algorithm;
+        fpga_pci_dev->adapter[smbus_temp_num].dev.parent = &pdev->dev;
+        //ACPI_COMPANION_SET(&priv->adapter.dev, ACPI_COMPANION(&dev->dev));
+        fpga_pci_dev->adapter[smbus_temp_num].retries = 3;
+
+        /* Default timeout in interrupt mode: 200 ms */
+    	fpga_pci_dev->adapter[smbus_temp_num].timeout = HZ / 5;
+
+        snprintf(fpga_pci_dev->adapter[smbus_temp_num].name, sizeof(fpga_pci_dev->adapter[smbus_temp_num].name),
+    		"%s%02d adapter", FPGA_SMBUS_NAME, smbus_temp_num);
+    	retval = i2c_add_adapter(&fpga_pci_dev->adapter[smbus_temp_num]);
+    	if (retval) {
+            ERROR_DEBUG( "[%s] err: 0x%x\n", __func__, retval);
+    		goto fail_to_add_i2c_adapter;
+    	}
+    }
+
+    fpga_init_smbus(fpga_pci_dev);
+
+    dev_info(&(pdev->dev), "FPGA SMBus is running with delay_ack %d us, delay_tip %d us, delay_busy %d us, and max_retry_time %d, PRER_LO_DEFAULT: 0x%x \n", delay_ack, delay_tip, delay_busy, max_retry_time, PRER_LO_DEFAULT);
+
+    return(0);
+
+fail_to_add_i2c_adapter:
+    for(smbus_temp_num = 0; smbus_temp_num < MAX_CHANNEL; smbus_temp_num++)
+    {
+        i2c_del_adapter(&fpga_pci_dev->adapter[smbus_temp_num]);
+    }
+
+fail_to_add_fpga_cdev:
+    free_irq(pdev->irq, (void *) fpga_pci_dev);
+    fpga_pci_dev->cdev_added = 0;
+    //fpga_pci_dev->irq = 0;
+#ifdef INTERRUPT_SUPPORT
+fail_to_request_irq:
+    pci_free_irq_vectors(pdev);
+    fpga_pci_dev->irq = 0;
+    //fpga_pci_dev->irq_vec_count = 0;
+fail_to_alloc_irq_vectors:
+    iounmap(fpga_pci_dev->fpga_base);
+    fpga_pci_dev->irq_vec_count = 0;
+    //fpga_pci_dev->fpga_base = NULL;
+#endif
+fail_to_remap_pci_resource:
+    pci_release_region(pdev, BAR0);
+    fpga_pci_dev->fpga_base = NULL;
+fail_to_request_pci_region:
+    pci_disable_device(pdev);
+    fpga_pci_dev->pci_region_requested = 0;
+    //fpga_pci_dev->pci_enabled = 0;
+fail_to_enable_pci_device:
+    device_destroy(fpga_pci_dev->fpga_class, fpga_pci_dev->fpga_dev_number);
+    fpga_pci_dev->pci_enabled = 0;
+    //fpga_pci_dev->fpga_udev = NULL;
+fail_to_create_fpga_udev:
+    class_destroy(fpga_pci_dev->fpga_class);
+    fpga_pci_dev->fpga_udev = NULL;
+    //fpga_class = NULL;
+fail_to_create_fpga_class:
+    unregister_chrdev_region(fpga_pci_dev->fpga_dev_number, fpga_dev_count);
+    fpga_pci_dev->fpga_class = NULL;
+    //fpga_dev_number = 0;
+fail_to_alloc_dev_number:
+    fpga_pci_dev->fpga_dev_number = 0;
+    kfree(fpga_pci_dev);
+    //fpga_pci_dev = NULL;
+fail_to_alloc_fpga_pci_dev:
+    pci_set_drvdata(pdev, (void *) NULL);
+
+    return(retval);
+}
+
+static void fpga_pci_remove(struct pci_dev *pdev)
+{
+    struct fpga_pci_device *fpga_pci_dev = NULL;
+    int smbus_temp_num;
+
+    I2C_DEBUG( "[%s]\n", __func__);
+
+    fpga_pci_dev = (struct fpga_pci_device *) pci_get_drvdata(pdev);
+    if (fpga_pci_dev)
+    {
+        if (fpga_pci_dev->cdev_added)
+        {
+            cdev_del(&(fpga_pci_dev->fpga_cdev));
+        }
+
+        if (fpga_pci_dev->irq > 0)
+        {
+            free_irq(pci_irq_vector(pdev, 0), (void *) fpga_pci_dev);
+            I2C_DEBUG( "[%s] free_irq()\n", __func__);
+        }
+
+        if (fpga_pci_dev->irq_vec_count > 0)
+        {
+            pci_free_irq_vectors(pdev);
+            I2C_DEBUG( "[%s] pci_free_irq_vectors()\n", __func__);
+        }
+
+        if (fpga_pci_dev->fpga_base != NULL)
+        {
+            iounmap(fpga_pci_dev->fpga_base);
+            I2C_DEBUG( "[%s] iounmap()\n", __func__);
+        }
+
+        if (fpga_pci_dev->pci_region_requested)
+        {
+            pci_release_region(pdev, BAR0);
+            I2C_DEBUG( "[%s] pci_release_region()\n", __func__);
+        }
+
+        if (fpga_pci_dev->pci_enabled)
+        {
+            pci_disable_device(pdev);
+            I2C_DEBUG( "[%s] pci_disable_device()\n", __func__);
+        }
+
+        if (fpga_pci_dev->fpga_udev)
+        {
+            device_destroy(fpga_pci_dev->fpga_class, fpga_pci_dev->fpga_dev_number);
+        }
+
+        if (fpga_pci_dev->fpga_class)
+        {
+            class_destroy(fpga_pci_dev->fpga_class);
+            I2C_DEBUG( "[%s] class_destroy()\n", __func__);
+        }
+
+        if (fpga_pci_dev->fpga_dev_number)
+        {
+            unregister_chrdev_region(fpga_pci_dev->fpga_dev_number, fpga_dev_count);
+            I2C_DEBUG( "[%s] unregister_chrdev_region()\n", __func__);
+        }
+
+        for(smbus_temp_num = 0; smbus_temp_num < MAX_CHANNEL; smbus_temp_num++)
+        {
+            i2c_del_adapter(&fpga_pci_dev->adapter[smbus_temp_num]);
+        }
+
+        kfree(fpga_pci_dev);
+        I2C_DEBUG( "[%s] kfree(fpga_pci_dev)\n", __func__);
+    }
+
+    return;
+}
+
+static struct pci_driver fpga_pci_driver = {
+    .name        = FPGA_DRIVER_NAME,
+    .id_table    = fpga_id_table,
+    .probe       = fpga_pci_probe,
+    .remove      = fpga_pci_remove,
+    .err_handler = &fpga_error_handlers,
+};
+
+static int __init fpga_module_init(void)
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    return pci_register_driver(&fpga_pci_driver);
+}
+
+static void __exit fpga_module_cleanup(void)
+{
+    I2C_DEBUG( "[%s]\n", __func__);
+    pci_unregister_driver(&fpga_pci_driver);
+    return;
+}
+
+module_init(fpga_module_init);
+module_exit(fpga_module_cleanup);
+
+MODULE_DEVICE_TABLE(pci, fpga_id_table);

--- a/recipes-kernel/accton-csp7551-mods/files/x86-64-accton-csp7551-sfp.c
+++ b/recipes-kernel/accton-csp7551-mods/files/x86-64-accton-csp7551-sfp.c
@@ -1,0 +1,1987 @@
+/*
+ * SFP driver for accton csp7551 sfp
+ *
+ * Copyright (C)  Brandon Chuang <brandon_chuang@accton.com.tw>
+ *
+ * Based on ad7414.c
+ * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.     See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/delay.h>
+
+#define DRIVER_NAME     "csp7550_sfp" /* Platform dependent */
+
+#define DEBUG_MODE 0
+
+#if (DEBUG_MODE == 1)
+    #define DEBUG_PRINT(fmt, args...)                                         \
+        printk (KERN_INFO "%s:%s[%d]: " fmt "\r\n", __FILE__, __FUNCTION__, __LINE__, ##args)
+#else
+    #define DEBUG_PRINT(fmt, args...)
+#endif
+
+#define NUM_OF_SFP_PORT           32
+#define EEPROM_NAME               "sfp_eeprom"
+#define EEPROM_SIZE               256    /*    256 byte eeprom */
+#define BIT_INDEX(i)              (1ULL << (i))
+#define USE_I2C_BLOCK_READ        0 /* Platform dependent */
+#define I2C_RW_RETRY_COUNT        10
+#define I2C_RW_RETRY_INTERVAL     60 /* ms */
+
+#define SFP_EEPROM_A0_I2C_ADDR (0xA0 >> 1)
+
+#define SFF8024_PHYSICAL_DEVICE_ID_ADDR     0x0
+#define SFF8024_DEVICE_ID_SFP               0x3
+#define SFF8024_DEVICE_ID_QSFP              0xC
+#define SFF8024_DEVICE_ID_QSFP_PLUS         0xD
+#define SFF8024_DEVICE_ID_QSFP28            0x11
+
+#define SFF8436_RX_LOS_ADDR                 3
+#define SFF8436_TX_FAULT_ADDR               4
+#define SFF8436_TX_DISABLE_ADDR             86
+
+#define MULTIPAGE_SUPPORT                   1
+
+#if (MULTIPAGE_SUPPORT == 1)
+/* fundamental unit of addressing for SFF_8472/SFF_8436 */
+#define SFF_8436_PAGE_SIZE 128
+/* 
+ * The current 8436 (QSFP) spec provides for only 4 supported
+ * pages (pages 0-3).  
+ * This driver is prepared to support more, but needs a register in the 
+ * EEPROM to indicate how many pages are supported before it is safe
+ * to implement more pages in the driver.
+ */
+#define SFF_8436_SPECED_PAGES 4
+#define SFF_8436_EEPROM_SIZE ((1 + SFF_8436_SPECED_PAGES) * SFF_8436_PAGE_SIZE)
+#define SFF_8436_EEPROM_UNPAGED_SIZE (2 * SFF_8436_PAGE_SIZE)
+/* 
+ * The current 8472 (SFP) spec provides for only 3 supported 
+ * pages (pages 0-2).
+ * This driver is prepared to support more, but needs a register in the 
+ * EEPROM to indicate how many pages are supported before it is safe
+ * to implement more pages in the driver.
+ */
+#define SFF_8472_SPECED_PAGES 3
+#define SFF_8472_EEPROM_SIZE ((3 + SFF_8472_SPECED_PAGES) * SFF_8436_PAGE_SIZE)
+#define SFF_8472_EEPROM_UNPAGED_SIZE (4 * SFF_8436_PAGE_SIZE)
+
+/* a few constants to find our way around the EEPROM */
+#define SFF_8436_PAGE_SELECT_REG 0x7F
+#define SFF_8436_PAGEABLE_REG 0x02
+#define SFF_8436_NOT_PAGEABLE (1<<2)
+#define SFF_8472_PAGEABLE_REG 0x40
+#define SFF_8472_PAGEABLE (1<<4)
+
+/*
+ * This parameter is to help this driver avoid blocking other drivers out
+ * of I2C for potentially troublesome amounts of time. With a 100 kHz I2C
+ * clock, one 256 byte read takes about 1/43 second which is excessive;
+ * but the 1/170 second it takes at 400 kHz may be quite reasonable; and
+ * at 1 MHz (Fm+) a 1/430 second delay could easily be invisible.
+ *
+ * This value is forced to be a power of two so that writes align on pages.
+ */
+static unsigned io_limit = SFF_8436_PAGE_SIZE;
+
+/*
+ * specs often allow 5 msec for a page write, sometimes 20 msec;
+ * it's important to recover from write timeouts.
+ */
+static unsigned write_timeout = 25;
+
+typedef enum qsfp_opcode {
+    QSFP_READ_OP = 0,
+    QSFP_WRITE_OP = 1
+} qsfp_opcode_e;
+#endif
+
+/* Platform dependent +++ */
+#define I2C_ADDR_CPLD1          0x62
+#define I2C_ADDR_CPLD2          0x64
+
+#define CPLD1_QSFP_RST_REG1     0x78
+#define CPLD1_QSFP_RST_REG2     0x79
+#define CPLD2_QSFP_RST_REG1     0x78
+#define CPLD2_QSFP_RST_REG2     0x79
+
+#define CPLD1_QSFP_LP_SEL_REG1  0x70
+#define CPLD1_QSFP_LP_SEL_REG2  0x71
+#define CPLD2_QSFP_LP_SEL_REG1  0x70
+#define CPLD2_QSFP_LP_SEL_REG2  0x71
+
+#define CPLD1_PRESETNT_REG1     0x60
+#define CPLD1_PRESETNT_REG2     0x61
+#define CPLD2_PRESETNT_REG1     0x60
+#define CPLD2_PRESETNT_REG2     0x61
+
+#define PORTS_PER_REG           8
+#define PORTS_PER_CPLD          16
+/* Platform dependent --- */
+static ssize_t show_port_number(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t show_present(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t sfp_show_tx_rx_status(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t qsfp_show_tx_rx_status(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t sfp_set_tx_disable(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
+static ssize_t qsfp_set_tx_disable(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
+static ssize_t sfp_eeprom_read(struct i2c_client *, u8, u8 *,int);
+static ssize_t sfp_eeprom_write(struct i2c_client *, u8 , const char *,int);
+static ssize_t get_mode_reset(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t set_mode_reset(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
+static ssize_t get_lp_mode_sel(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t set_lp_mode_sel(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
+extern int accton_i2c_cpld_read (u8 cpld_addr, u8 reg);
+extern int accton_i2c_cpld_write(u8 cpld_addr, u8 reg, u8 value);
+
+enum sfp_sysfs_attributes {
+    PRESENT,
+    PRESENT_ALL,
+    PORT_NUMBER,
+    PORT_TYPE,
+    DDM_IMPLEMENTED,
+    TX_FAULT,
+    TX_FAULT1,
+    TX_FAULT2,
+    TX_FAULT3,
+    TX_FAULT4,
+    TX_DISABLE,
+    TX_DISABLE1,
+    TX_DISABLE2,
+    TX_DISABLE3,
+    TX_DISABLE4,
+    RX_LOS,
+    RX_LOS1,
+    RX_LOS2,
+    RX_LOS3,
+    RX_LOS4,
+    RX_LOS_ALL,
+    SFP_MOD_RST,
+    SFP_LP_MOD_SEL
+};
+
+/* SFP/QSFP common attributes for sysfs */
+static SENSOR_DEVICE_ATTR(sfp_port_number, S_IRUGO, show_port_number, NULL, PORT_NUMBER);
+static SENSOR_DEVICE_ATTR(sfp_is_present, S_IRUGO, show_present, NULL, PRESENT);
+static SENSOR_DEVICE_ATTR(sfp_is_present_all, S_IRUGO, show_present, NULL, PRESENT_ALL);
+static SENSOR_DEVICE_ATTR(sfp_rx_los, S_IRUGO, sfp_show_tx_rx_status, NULL, RX_LOS);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable, S_IWUSR | S_IRUGO, sfp_show_tx_rx_status, sfp_set_tx_disable, TX_DISABLE);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault, S_IRUGO, sfp_show_tx_rx_status, NULL, TX_FAULT);
+
+/* QSFP attributes for sysfs */
+static SENSOR_DEVICE_ATTR(sfp_rx_los1, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS1);
+static SENSOR_DEVICE_ATTR(sfp_rx_los2, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS2);
+static SENSOR_DEVICE_ATTR(sfp_rx_los3, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS3);
+static SENSOR_DEVICE_ATTR(sfp_rx_los4, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS4);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable1, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE1);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable2, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE2);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable3, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE3);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable4, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE4);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault1, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT1);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault2, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT2);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault3, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT3);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault4, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT4);
+static SENSOR_DEVICE_ATTR(sfp_mod_rst, S_IWUSR | S_IRUGO, get_mode_reset, set_mode_reset, SFP_MOD_RST);
+static SENSOR_DEVICE_ATTR(sfp_lp_mod_sel, S_IWUSR | S_IRUGO, get_lp_mode_sel, set_lp_mode_sel, SFP_LP_MOD_SEL);
+
+static struct attribute *qsfp_attributes[] = {
+    &sensor_dev_attr_sfp_port_number.dev_attr.attr,
+    &sensor_dev_attr_sfp_is_present.dev_attr.attr,
+    &sensor_dev_attr_sfp_is_present_all.dev_attr.attr,
+    &sensor_dev_attr_sfp_rx_los.dev_attr.attr,
+    &sensor_dev_attr_sfp_rx_los1.dev_attr.attr,
+    &sensor_dev_attr_sfp_rx_los2.dev_attr.attr,
+    &sensor_dev_attr_sfp_rx_los3.dev_attr.attr,
+    &sensor_dev_attr_sfp_rx_los4.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_disable.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_disable1.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_disable2.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_disable3.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_disable4.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_fault.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_fault1.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_fault2.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_fault3.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_fault4.dev_attr.attr,
+    &sensor_dev_attr_sfp_mod_rst.dev_attr.attr,
+    &sensor_dev_attr_sfp_lp_mod_sel.dev_attr.attr,
+    NULL
+};
+
+/* SFP msa attributes for sysfs */
+static SENSOR_DEVICE_ATTR(sfp_rx_los_all,  S_IRUGO, sfp_show_tx_rx_status, NULL, RX_LOS_ALL);
+static struct attribute *sfp_msa_attributes[] = {
+    &sensor_dev_attr_sfp_port_number.dev_attr.attr,
+    &sensor_dev_attr_sfp_is_present.dev_attr.attr,
+    &sensor_dev_attr_sfp_is_present_all.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_fault.dev_attr.attr,
+    &sensor_dev_attr_sfp_rx_los.dev_attr.attr,
+    &sensor_dev_attr_sfp_rx_los_all.dev_attr.attr,
+    &sensor_dev_attr_sfp_tx_disable.dev_attr.attr,
+    NULL
+};
+
+/* Platform dependent +++ */
+#define CPLD_PORT_TO_FRONT_PORT(port)  (port+1)
+
+enum port_numbers {
+csp7551_port1,  csp7551_port2,  csp7551_port3,  csp7551_port4,  
+csp7551_port5,  csp7551_port6,  csp7551_port7,  csp7551_port8, 
+csp7551_port9,  csp7551_port10, csp7551_port11, csp7551_port12, 
+csp7551_port13, csp7551_port14, csp7551_port15, csp7551_port16,
+csp7551_port17, csp7551_port18, csp7551_port19, csp7551_port20,
+csp7551_port21, csp7551_port22, csp7551_port23, csp7551_port24, 
+csp7551_port25, csp7551_port26, csp7551_port27, csp7551_port28, 
+csp7551_port29, csp7551_port30, csp7551_port31, csp7551_port32
+};
+
+#define I2C_DEV_ID(x) { #x, x}
+
+static const struct i2c_device_id sfp_device_id[] = {
+I2C_DEV_ID(csp7551_port1),
+I2C_DEV_ID(csp7551_port2),
+I2C_DEV_ID(csp7551_port3),
+I2C_DEV_ID(csp7551_port4),
+I2C_DEV_ID(csp7551_port5),
+I2C_DEV_ID(csp7551_port6),
+I2C_DEV_ID(csp7551_port7),
+I2C_DEV_ID(csp7551_port8),
+I2C_DEV_ID(csp7551_port9),
+I2C_DEV_ID(csp7551_port10),
+I2C_DEV_ID(csp7551_port11),
+I2C_DEV_ID(csp7551_port12),
+I2C_DEV_ID(csp7551_port13),
+I2C_DEV_ID(csp7551_port14),
+I2C_DEV_ID(csp7551_port15),
+I2C_DEV_ID(csp7551_port16),
+I2C_DEV_ID(csp7551_port17),
+I2C_DEV_ID(csp7551_port18),
+I2C_DEV_ID(csp7551_port19),
+I2C_DEV_ID(csp7551_port20),
+I2C_DEV_ID(csp7551_port21),
+I2C_DEV_ID(csp7551_port22),
+I2C_DEV_ID(csp7551_port23),
+I2C_DEV_ID(csp7551_port24),
+I2C_DEV_ID(csp7551_port25),
+I2C_DEV_ID(csp7551_port26),
+I2C_DEV_ID(csp7551_port27),
+I2C_DEV_ID(csp7551_port28),
+I2C_DEV_ID(csp7551_port29),
+I2C_DEV_ID(csp7551_port30),
+I2C_DEV_ID(csp7551_port31),
+I2C_DEV_ID(csp7551_port32),
+{ /* LIST END */ }
+};
+MODULE_DEVICE_TABLE(i2c, sfp_device_id);
+/* Platform dependent --- */
+
+enum driver_type_e {
+    DRIVER_TYPE_SFP_MSA,
+    DRIVER_TYPE_SFP_DDM,
+    DRIVER_TYPE_QSFP,
+    DRIVER_TYPE_XFP
+};
+
+/* Each client has this additional data
+ */
+struct eeprom_data {
+    char                    valid;          /* !=0 if registers are valid */
+    unsigned long           last_updated;   /* In jiffies */
+    struct bin_attribute    bin;            /* eeprom data */
+};
+
+struct sfp_msa_data {
+    char                    valid;          /* !=0 if registers are valid */
+    unsigned long           last_updated;   /* In jiffies */
+    u64                     status[6];      /* bit0:port0, bit1:port1 and so on */
+    /* index 0 => tx_fail
+    		 1 => tx_disable
+    		 2 => rx_loss
+    		 3 => device id
+    		 4 => 10G Ethernet Compliance Codes
+    			  to distinguish SFP or SFP+
+    		 5 => DIAGNOSTIC MONITORING TYPE */
+    struct eeprom_data      eeprom;
+#if (MULTIPAGE_SUPPORT == 1)
+    struct i2c_client	   *ddm_client;     /* dummy client instance for 0xA2 */
+#endif
+};
+
+struct qsfp_data {
+    char                valid;          /* !=0 if registers are valid */
+    unsigned long       last_updated;   /* In jiffies */
+    u8                  status[3];      /* bit0:port0, bit1:port1 and so on */
+                                        /* index 0 => tx_fail
+                                             1 => tx_disable
+                                             2 => rx_loss */
+
+    u8                  device_id;
+    struct eeprom_data  eeprom;
+};
+
+struct sfp_port_data {
+    struct mutex            update_lock;
+    enum driver_type_e      driver_type;
+    int                     port;       /* CPLD port index */
+    u64                     present;    /* present status, bit0:port0, bit1:port1 and so on */
+
+    struct sfp_msa_data     *msa;
+    struct qsfp_data        *qsfp;
+
+    struct i2c_client       *client;
+#if (MULTIPAGE_SUPPORT == 1)
+    int use_smbus;
+    u8 *writebuf;
+    unsigned write_max;
+#endif
+};
+
+#if (MULTIPAGE_SUPPORT == 1)
+static ssize_t sfp_port_read_write(struct sfp_port_data *port_data,
+        char *buf, loff_t off, size_t len, qsfp_opcode_e opcode);
+#endif
+static ssize_t show_port_number(struct device *dev, struct device_attribute *da,
+             char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    DEBUG_PRINT("%d\n", CPLD_PORT_TO_FRONT_PORT(data->port));
+    return sprintf(buf, "%d\n", CPLD_PORT_TO_FRONT_PORT(data->port));
+}
+
+/* Platform dependent +++ */
+static struct sfp_port_data *sfp_update_present(struct i2c_client *client)
+{
+    int i = 0;
+    u8 regs[] = {CPLD1_PRESETNT_REG1, CPLD1_PRESETNT_REG2, CPLD2_PRESETNT_REG1, CPLD2_PRESETNT_REG2};
+    int status = -1;
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+
+    DEBUG_PRINT("Starting sfp present status update");
+    mutex_lock(&data->update_lock);
+
+    /* Read present status of port 1~32 */
+    data->present = 0;
+    for (i = 0; i < ARRAY_SIZE(regs); i++) {
+        if(i < 2) {
+            status = accton_i2c_cpld_read(I2C_ADDR_CPLD1, regs[i]);
+            if (status < 0) {
+                DEBUG_PRINT("cpld(0x62) reg(0x%x) err %d", regs[i], status);
+                goto exit;
+            }
+        }
+        else
+        {
+            status = accton_i2c_cpld_read(I2C_ADDR_CPLD2, regs[i]);
+            if (status < 0) {
+                DEBUG_PRINT("cpld(0x64) reg(0x%x) err %d", regs[i], status);
+                goto exit;
+            }
+        }
+        
+        DEBUG_PRINT("Present status = 0x%lx", data->present);        
+        data->present |= (u64)status << (i*8);
+    }
+
+    DEBUG_PRINT("Present status = 0x%lx", data->present);
+exit:
+    mutex_unlock(&data->update_lock);
+    return (status < 0) ? ERR_PTR(status) : data;
+}
+
+
+static struct sfp_port_data *sfp_update_present_by_port(struct i2c_client *client, int port)
+{
+    u8 reg = CPLD1_PRESETNT_REG1;
+    u8 i2c_addr = I2C_ADDR_CPLD1;
+    int bit_shift = 0;
+    int status = -1;
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+
+    DEBUG_PRINT("Starting sfp present status update, port:%d\n", port);
+    mutex_lock(&data->update_lock);
+
+    /* Read present status of the port */
+    data->present = 0;
+    if(0 <= port && port <= 7)
+    {
+        i2c_addr = I2C_ADDR_CPLD1;
+        reg = CPLD1_PRESETNT_REG1;
+        bit_shift = 0;
+    }
+    else if(8 <= port && port <= 15)
+    {
+        i2c_addr = I2C_ADDR_CPLD1;
+        reg = CPLD1_PRESETNT_REG2;
+        bit_shift = 1;
+    }
+    else if(16 <= port && port <= 23)
+    {
+        i2c_addr = I2C_ADDR_CPLD2;
+        reg = CPLD2_PRESETNT_REG1;
+        bit_shift = 2;
+    }
+    else if(24 <= port && port <= 31)
+    {
+        i2c_addr = I2C_ADDR_CPLD2;
+        reg = CPLD2_PRESETNT_REG2;
+        bit_shift = 3;
+    }
+    else
+    {
+        status = -ENXIO;
+        goto exit;
+    }
+
+    status = accton_i2c_cpld_read(i2c_addr, reg);
+    if (status < 0) {
+        DEBUG_PRINT("cpld(0x%x) reg(0x%x) err %d\n", i2c_addr, reg, status);
+        goto exit;
+    }
+
+    data->present |= (u64)status << (bit_shift*8);
+    DEBUG_PRINT("Present status = 0x%lx\n", data->present);
+exit:
+    mutex_unlock(&data->update_lock);
+    return (status < 0) ? ERR_PTR(status) : data;
+}
+/* Platform dependent --- */
+
+
+static struct sfp_port_data* sfp_update_tx_rx_status(struct device *dev)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    int i = 0, j = 0;
+    int status = -1;
+
+    if (time_before(jiffies, data->msa->last_updated + HZ + HZ / 2) && data->msa->valid) {
+        return data;
+    }
+
+    DEBUG_PRINT("Starting csp7551 sfp tx rx status update");
+    mutex_lock(&data->update_lock);
+    data->msa->valid = 0;
+    memset(data->msa->status, 0, sizeof(data->msa->status));
+
+    /* Read status of port 1~48(SFP port) */
+    for (i = 0; i < 2; i++) {
+        for (j = 0; j < 9; j++) {
+            u8 reg;
+            unsigned short cpld_addr;
+            reg 	  = 0xc+j;
+            cpld_addr = I2C_ADDR_CPLD1 + i*2;
+
+            status	= accton_i2c_cpld_read(cpld_addr, reg);
+            if (unlikely(status < 0)) {
+                dev_dbg(&client->dev, "cpld(0x%x) reg(0x%x) err %d\n", cpld_addr, reg, status);
+                goto exit;
+            }
+
+            data->msa->status[j/3] |= (u64)status << ((i*24) + (j%3)*8);
+        }
+    }
+
+    data->msa->valid = 1;
+    data->msa->last_updated = jiffies;
+
+exit:
+    mutex_unlock(&data->update_lock);
+    return (status < 0) ? ERR_PTR(status) : data;
+}
+
+static ssize_t sfp_set_tx_disable(struct device *dev, struct device_attribute *da,
+                                  const char *buf, size_t count)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    unsigned short cpld_addr = 0;
+    u8 cpld_reg = 0, cpld_val = 0, cpld_bit = 0;
+    long disable;
+    int error;
+
+    if (data->driver_type == DRIVER_TYPE_QSFP) {
+        return qsfp_set_tx_disable(dev, da, buf, count);
+    }
+
+    error = kstrtol(buf, 10, &disable);
+    if (error) {
+        return error;
+    }
+
+    mutex_lock(&data->update_lock);
+
+    if(data->port < 16) {
+        cpld_addr = I2C_ADDR_CPLD1;
+        cpld_reg  = 0xFF + data->port / 8;
+        cpld_bit  = 1 << (data->port % 8);
+    }
+    else { /* port 16 ~ 31 */
+        cpld_addr = I2C_ADDR_CPLD2;
+        cpld_reg  = 0xFF + (data->port - 24) / 8;
+        cpld_bit  = 1 << (data->port % 8);
+    }
+
+    /* Read current status */
+    cpld_val = accton_i2c_cpld_read(cpld_addr, cpld_reg);
+
+    /* Update tx_disable status */
+    if (disable) {
+        data->msa->status[1] |= BIT_INDEX(data->port);
+        cpld_val |= cpld_bit;
+    }
+    else {
+        data->msa->status[1] &= ~BIT_INDEX(data->port);
+        cpld_val &= ~cpld_bit;
+    }
+
+    accton_i2c_cpld_write(cpld_addr, cpld_reg, cpld_val);
+    mutex_unlock(&data->update_lock);
+    return count;
+}
+
+static int sfp_is_port_present(struct i2c_client *client, int port)
+{
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+
+    data = sfp_update_present_by_port(client, port);
+    if (IS_ERR(data)) {
+        return PTR_ERR(data);
+    }
+
+    return (data->present & BIT_INDEX(data->port)) ? 0 : 1; /* Platform dependent */
+}
+
+
+/* Platform dependent +++ */
+static ssize_t show_present(struct device *dev, struct device_attribute *da, char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct i2c_client *client = to_i2c_client(dev);
+
+    if (PRESENT_ALL == attr->index) {
+        int i;
+        u8 values[4]  = {0};
+        struct sfp_port_data *data = sfp_update_present(client);
+        
+        if (IS_ERR(data)) {
+            return PTR_ERR(data);
+        }
+
+        for (i = 0; i < ARRAY_SIZE(values); i++) {
+            values[i] = ~(u8)(data->present >> (i * 8));
+        }
+
+        /* Return values 1 -> 56 in order */
+        return sprintf(buf, "%.2x %.2x %.2x %.2x \n", values[0], values[1], values[2], values[3]);
+    }
+    else {
+        struct sfp_port_data *data = i2c_get_clientdata(client);
+        int present = sfp_is_port_present(client, data->port);
+
+        if (present < 0) {
+            return present;
+        }
+
+        /* PRESENT */
+        return sprintf(buf, "%d\n", present);
+    }
+}
+/* Platform dependent --- */
+
+static struct sfp_port_data *qsfp_update_tx_rx_status(struct device *dev)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    int i, status = -1;
+    u8 buf = 0;
+    u8 reg[] = {SFF8436_TX_FAULT_ADDR, SFF8436_TX_DISABLE_ADDR, SFF8436_RX_LOS_ADDR};
+    DEBUG_PRINT("REG[0-2]:%d,%d,%d",reg[0],reg[1],reg[2]);
+
+    if (time_before(jiffies, data->qsfp->last_updated + HZ + HZ / 2) && data->qsfp->valid) {
+        return data;
+    }
+
+    DEBUG_PRINT("Starting sfp tx rx status update");
+    mutex_lock(&data->update_lock);
+    data->qsfp->valid = 0;
+    memset(data->qsfp->status, 0, sizeof(data->qsfp->status));
+
+    /* Notify device to update tx fault/ tx disable/ rx los status */
+    for (i = 0; i < ARRAY_SIZE(reg); i++) {
+        status = sfp_eeprom_read(client, reg[i], &buf, sizeof(buf));
+        if (unlikely(status < 0)) {
+    DEBUG_PRINT("status:%d",status);
+            goto exit;
+        }
+    }
+    msleep(200);
+
+    /* Read actual tx fault/ tx disable/ rx los status */
+    for (i = 0; i < ARRAY_SIZE(reg); i++) {
+        status = sfp_eeprom_read(client, reg[i], &buf, sizeof(buf));
+        if (unlikely(status < 0)) {
+    DEBUG_PRINT("status:%d",status);
+            goto exit;
+        }
+
+        DEBUG_PRINT("qsfp reg(0x%x) status = (0x%x)", reg[i], data->qsfp->status[i]);
+        data->qsfp->status[i] = (buf & 0xF);
+    }
+
+    data->qsfp->valid = 1;
+    data->qsfp->last_updated = jiffies;
+
+exit:
+    mutex_unlock(&data->update_lock);
+    return (status < 0) ? ERR_PTR(status) : data;
+}
+
+static ssize_t get_mode_reset(struct device *dev, struct device_attribute *da, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    u8  cpld_val = 0;
+    int port_bit;
+    int status = -EINVAL;
+    u8 cpld_addr[] = {I2C_ADDR_CPLD1, I2C_ADDR_CPLD2};
+    u8 reset_reg_addr[] = {CPLD1_QSFP_RST_REG1, CPLD1_QSFP_RST_REG2, CPLD2_QSFP_RST_REG1, CPLD2_QSFP_RST_REG2};
+
+    mutex_lock(&data->update_lock);
+
+    port_bit = data->port;
+    cpld_val = accton_i2c_cpld_read(cpld_addr[port_bit/PORTS_PER_CPLD], reset_reg_addr[port_bit/PORTS_PER_REG]);
+
+    DEBUG_PRINT("[ROY]%s#%d, %x from %x\n", __func__, __LINE__, cpld_val, cpld_addr[port_bit/PORTS_PER_CPLD]);
+
+    cpld_val = cpld_val & 0xFF;
+    cpld_val = cpld_val & BIT_INDEX(port_bit%PORTS_PER_REG);
+
+    DEBUG_PRINT("[ROY]%s#%d, %x of bit %d\n", __func__, __LINE__, cpld_val, port_bit);
+
+    status = snprintf(buf, PAGE_SIZE - 1, "%d\r\n", cpld_val>>(port_bit%PORTS_PER_REG));
+
+    mutex_unlock(&data->update_lock);
+
+    return status;
+}
+
+static ssize_t set_mode_reset(struct device *dev, struct device_attribute *da, const char *buf, size_t count)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    u8 cpld_val = 0;
+    long reset;
+    int error, port_bit;
+    u8 cpld_addr[] = {I2C_ADDR_CPLD1, I2C_ADDR_CPLD2};
+    u8 reset_reg_addr[] = {CPLD1_QSFP_RST_REG1, CPLD1_QSFP_RST_REG2, CPLD2_QSFP_RST_REG1, CPLD2_QSFP_RST_REG2};
+
+    DEBUG_PRINT("[ROY]%s#%d, port:%d\n", __func__, __LINE__, data->port);
+
+    port_bit = data->port;
+    error = kstrtol(buf, 10, &reset);
+
+    DEBUG_PRINT("[ROY]%s#%d, %s == %d\n", __func__, __LINE__, buf, error);
+    if (error) {
+        return error;
+    }
+    mutex_lock(&data->update_lock);
+
+    cpld_val = accton_i2c_cpld_read(cpld_addr[port_bit/PORTS_PER_CPLD], reset_reg_addr[port_bit/PORTS_PER_REG]);
+    DEBUG_PRINT("[ROY]%s#%d, %x\n", __func__, __LINE__, cpld_val);
+    /* Update lp_mode status */
+    if (reset)
+    {
+        cpld_val |= BIT_INDEX(port_bit%PORTS_PER_REG);
+    }
+    else
+    {
+        cpld_val &= ~BIT_INDEX(port_bit%PORTS_PER_REG);
+    }
+    DEBUG_PRINT("[ROY]%s#%d, %x to %x\n", __func__, __LINE__, cpld_val, cpld_addr[port_bit/PORTS_PER_CPLD]);
+
+    accton_i2c_cpld_write(cpld_addr[port_bit/PORTS_PER_CPLD], reset_reg_addr[port_bit/PORTS_PER_REG], cpld_val);
+
+    mutex_unlock(&data->update_lock);
+
+    return count;
+}
+
+static ssize_t get_lp_mode_sel(struct device *dev, struct device_attribute *da, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    u8  cpld_val = 0;
+    int port_bit;
+    int status = -EINVAL;
+    u8 cpld_addr[] = {I2C_ADDR_CPLD1, I2C_ADDR_CPLD2};
+    u8 reset_reg_addr[] = {CPLD1_QSFP_LP_SEL_REG1, CPLD1_QSFP_LP_SEL_REG2, CPLD2_QSFP_LP_SEL_REG1, CPLD2_QSFP_LP_SEL_REG2};
+
+    mutex_lock(&data->update_lock);
+
+    port_bit = data->port;
+    cpld_val = accton_i2c_cpld_read(cpld_addr[port_bit/PORTS_PER_CPLD], reset_reg_addr[port_bit/PORTS_PER_REG]);
+
+    DEBUG_PRINT("[ROY]%s#%d, %x from %x\n", __func__, __LINE__, cpld_val, cpld_addr[port_bit/PORTS_PER_CPLD]);
+
+    cpld_val = cpld_val & 0xFF;
+    cpld_val = cpld_val & BIT_INDEX(port_bit%PORTS_PER_REG);
+
+    DEBUG_PRINT("[ROY]%s#%d, %x of bit %d\n", __func__, __LINE__, cpld_val, port_bit);
+
+    status = snprintf(buf, PAGE_SIZE - 1, "%d\r\n", cpld_val>>(port_bit%PORTS_PER_REG));
+
+    mutex_unlock(&data->update_lock);
+
+    return status;
+}
+
+static ssize_t set_lp_mode_sel(struct device *dev, struct device_attribute *da, const char *buf, size_t count)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+    u8 cpld_val = 0;
+    long reset;
+    int error, port_bit;
+    u8 cpld_addr[] = {I2C_ADDR_CPLD1, I2C_ADDR_CPLD2};
+    u8 reset_reg_addr[] = {CPLD1_QSFP_LP_SEL_REG1, CPLD1_QSFP_LP_SEL_REG2, CPLD2_QSFP_LP_SEL_REG1, CPLD2_QSFP_LP_SEL_REG2};
+
+    DEBUG_PRINT("[ROY]%s#%d, port:%d\n", __func__, __LINE__, data->port);
+
+    port_bit = data->port;
+    error = kstrtol(buf, 10, &reset);
+
+    DEBUG_PRINT("[ROY]%s#%d, %s == %d\n", __func__, __LINE__, buf, error);
+    if (error) {
+        return error;
+    }
+    mutex_lock(&data->update_lock);
+
+    cpld_val = accton_i2c_cpld_read(cpld_addr[port_bit/PORTS_PER_CPLD], reset_reg_addr[port_bit/PORTS_PER_REG]);
+    DEBUG_PRINT("[ROY]%s#%d, %x\n", __func__, __LINE__, cpld_val);
+    /* Update lp_mode status */
+    if (reset)
+    {
+        cpld_val |= BIT_INDEX(port_bit%PORTS_PER_REG);
+    }
+    else
+    {
+        cpld_val &= ~BIT_INDEX(port_bit%PORTS_PER_REG);
+    }
+    DEBUG_PRINT("[ROY]%s#%d, %x to %x\n", __func__, __LINE__, cpld_val, cpld_addr[port_bit/PORTS_PER_CPLD]);
+
+    accton_i2c_cpld_write(cpld_addr[port_bit/PORTS_PER_CPLD], reset_reg_addr[port_bit/PORTS_PER_REG], cpld_val);
+
+    mutex_unlock(&data->update_lock);
+
+    return count;
+}
+
+static ssize_t qsfp_show_tx_rx_status(struct device *dev, struct device_attribute *da, char *buf)
+{
+    int present;
+    u8 val = 0;
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+
+    present = sfp_is_port_present(client, data->port);
+    if (present < 0) {
+        return present;
+    }
+
+    if (present == 0) {
+        /* port is not present */
+        return -ENXIO;
+    }
+
+    data = qsfp_update_tx_rx_status(dev);
+    if (IS_ERR(data)) {
+        return PTR_ERR(data);
+    }
+
+    switch (attr->index) {
+    case TX_FAULT:
+        val = !!(data->qsfp->status[2] & 0xF);
+        break;
+    case TX_FAULT1:
+    case TX_FAULT2:
+    case TX_FAULT3:
+    case TX_FAULT4:
+        val = !!(data->qsfp->status[2] & BIT_INDEX(attr->index - TX_FAULT1));
+        break;
+    case TX_DISABLE:
+        val = data->qsfp->status[1] & 0xF;
+        break;
+    case TX_DISABLE1:
+    case TX_DISABLE2:
+    case TX_DISABLE3:
+    case TX_DISABLE4:
+        val = !!(data->qsfp->status[1] & BIT_INDEX(attr->index - TX_DISABLE1));
+        break;
+    case RX_LOS:
+        val = !!(data->qsfp->status[0] & 0xF);
+        break;
+    case RX_LOS1:
+    case RX_LOS2:
+    case RX_LOS3:
+    case RX_LOS4:
+        val = !!(data->qsfp->status[0] & BIT_INDEX(attr->index - RX_LOS1));
+        break;
+    default:
+        break;
+    }
+
+    return sprintf(buf, "%d\n", val);
+}
+
+static ssize_t qsfp_set_tx_disable(struct device *dev, struct device_attribute *da,
+            const char *buf, size_t count)
+{
+    long disable;
+    int status;
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);    
+
+    status = sfp_is_port_present(client, data->port);
+    if (status < 0) {
+        return status;
+    }
+
+    if (!status) {
+        /* port is not present */
+        return -ENXIO;
+    }
+
+    status = kstrtol(buf, 10, &disable);
+    if (status) {
+        return status;
+    }
+
+    data = qsfp_update_tx_rx_status(dev);
+    if (IS_ERR(data)) {
+        return PTR_ERR(data);
+    }
+
+    mutex_lock(&data->update_lock);
+
+    if (attr->index == TX_DISABLE) {
+        if (disable) {
+            data->qsfp->status[1] |= 0xF;
+        }
+        else {
+            data->qsfp->status[1] &= ~0xF;
+        }
+    }
+    else {/* TX_DISABLE1 ~ TX_DISABLE4*/
+        if (disable) {
+            data->qsfp->status[1] |= (1 << (attr->index - TX_DISABLE1));
+        }
+        else {
+            data->qsfp->status[1] &= ~(1 << (attr->index - TX_DISABLE1));
+        }
+    }
+
+    DEBUG_PRINT("index = (%d), status = (0x%x)", attr->index, data->qsfp->status[1]);
+    status = sfp_eeprom_write(data->client, SFF8436_TX_DISABLE_ADDR, &data->qsfp->status[1], sizeof(data->qsfp->status[1]));
+    if (unlikely(status < 0)) {
+        count = status;
+    }
+
+    mutex_unlock(&data->update_lock);
+    return count;
+}
+
+/* Platform dependent +++ */
+static ssize_t sfp_show_tx_rx_status(struct device *dev, struct device_attribute *da,
+                                     char *buf)
+{
+    u8 val = 0, index = 0;
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+
+    if (data->driver_type == DRIVER_TYPE_QSFP) {
+        return qsfp_show_tx_rx_status(dev, da, buf);
+    }
+
+    data = sfp_update_tx_rx_status(dev);
+    if (IS_ERR(data)) {
+        return PTR_ERR(data);
+    }
+
+    if(attr->index == RX_LOS_ALL) {
+        int i = 0;
+        u8 values[6] = {0};
+
+        for (i = 0; i < ARRAY_SIZE(values); i++) {
+            values[i] = (u8)(data->msa->status[2] >> (i * 8));
+        }
+
+        /** Return values 1 -> 48 in order */
+        return sprintf(buf, "%.2x %.2x %.2x %.2x %.2x %.2x\n",
+                       values[0], values[1], values[2],
+                       values[3], values[4], values[5]);
+    }
+
+    switch (attr->index) {
+    case TX_FAULT:
+        index = 0;
+        break;
+    case TX_DISABLE:
+        index = 1;
+        break;
+    case RX_LOS:
+        index = 2;
+        break;
+    default:
+        return 0;
+    }
+
+    val = (data->msa->status[index] & BIT_INDEX(data->port)) ? 1 : 0;
+    return sprintf(buf, "%d\n", val);
+}
+/* Platform dependent --- */
+static ssize_t sfp_eeprom_write(struct i2c_client *client, u8 command, const char *data,
+              int data_len)
+{
+#if USE_I2C_BLOCK_READ
+    int status, retry = I2C_RW_RETRY_COUNT;
+
+    if (data_len > I2C_SMBUS_BLOCK_MAX) {
+        data_len = I2C_SMBUS_BLOCK_MAX;
+    }
+
+    while (retry) {
+        status = i2c_smbus_write_i2c_block_data(client, command, data_len, data);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    if (unlikely(status < 0)) {
+        return status;
+    }
+
+    return data_len;
+#else
+    int status, retry = I2C_RW_RETRY_COUNT;
+
+    while (retry) {
+        status = i2c_smbus_write_byte_data(client, command, *data);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    if (unlikely(status < 0)) {
+        return status;
+    }
+
+    return 1;
+#endif
+
+
+}
+
+#if (MULTIPAGE_SUPPORT == 0)
+static ssize_t sfp_port_write(struct sfp_port_data *data,
+                          const char *buf, loff_t off, size_t count)
+{
+    ssize_t retval = 0;
+
+    if (unlikely(!count)) {
+        return count;
+    }
+
+    /*
+     * Write data to chip, protecting against concurrent updates
+     * from this host, but not from other I2C masters.
+     */
+    mutex_lock(&data->update_lock);
+
+    while (count) {
+        ssize_t status;
+
+        status = sfp_eeprom_write(data->client, off, buf, count);
+        if (status <= 0) {
+            if (retval == 0) {
+                retval = status;
+            }
+            break;
+        }
+        buf += status;
+        off += status;
+        count -= status;
+        retval += status;
+    }
+
+    mutex_unlock(&data->update_lock);
+    return retval;
+}
+#endif
+
+static ssize_t sfp_bin_write(struct file *filp, struct kobject *kobj,
+                struct bin_attribute *attr,
+                char *buf, loff_t off, size_t count)
+{
+    int present;
+    struct sfp_port_data *data;
+    DEBUG_PRINT("%s(%d) offset = (%d), count = (%d)", off, count);
+    data = dev_get_drvdata(container_of(kobj, struct device, kobj));
+
+    present = sfp_is_port_present(data->client, data->port);
+    if (present < 0) {
+        return present;
+    }
+
+    if (present == 0) {
+        /* port is not present */
+        return -ENODEV;
+    }
+
+#if (MULTIPAGE_SUPPORT == 1)
+    return sfp_port_read_write(data, buf, off, count, QSFP_WRITE_OP);
+#else
+    return sfp_port_write(data, buf, off, count);
+#endif
+}
+
+static ssize_t sfp_eeprom_read(struct i2c_client *client, u8 command, u8 *data,
+              int data_len)
+{
+#if USE_I2C_BLOCK_READ
+    int status, retry = I2C_RW_RETRY_COUNT;
+
+    if (data_len > I2C_SMBUS_BLOCK_MAX) {
+        data_len = I2C_SMBUS_BLOCK_MAX;
+    }
+
+    while (retry) {
+        status = i2c_smbus_read_i2c_block_data(client, command, data_len, data);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    if (unlikely(status < 0)) {
+        goto abort;
+    }
+    if (unlikely(status != data_len)) {
+        status = -EIO;
+        goto abort;
+    }
+
+    //result = data_len;
+
+abort:
+    return status;
+#else
+    int status, retry = I2C_RW_RETRY_COUNT;
+
+    while (retry) {
+        status = i2c_smbus_read_byte_data(client, command);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    if (unlikely(status < 0)) {
+        dev_dbg(&client->dev, "sfp read byte data failed, command(0x%2x), data(0x%2x)\r\n", command, status);
+        goto abort;
+    }
+
+    *data  = (u8)status;
+    status = 1;
+
+abort:
+    return status;
+#endif
+}
+
+#if (MULTIPAGE_SUPPORT == 1)
+/*-------------------------------------------------------------------------*/
+/*
+ * This routine computes the addressing information to be used for
+ * a given r/w request.
+ *
+ * Task is to calculate the client (0 = i2c addr 50, 1 = i2c addr 51),
+ * the page, and the offset.
+ *
+ * Handles both SFP and QSFP.  
+ *     For SFP, offset 0-255 are on client[0], >255 is on client[1]
+ *     Offset 256-383 are on the lower half of client[1]
+ *     Pages are accessible on the upper half of client[1].
+ *     Offset >383 are in 128 byte pages mapped into the upper half
+ *
+ *     For QSFP, all offsets are on client[0]
+ *     offset 0-127 are on the lower half of client[0] (no paging)
+ *     Pages are accessible on the upper half of client[1].
+ *     Offset >127 are in 128 byte pages mapped into the upper half
+ *
+ *     Callers must not read/write beyond the end of a client or a page
+ *     without recomputing the client/page.  Hence offset (within page)
+ *     plus length must be less than or equal to 128.  (Note that this
+ *     routine does not have access to the length of the call, hence 
+ *     cannot do the validity check.)
+ *
+ * Offset within Lower Page 00h and Upper Page 00h are not recomputed
+ */
+static uint8_t sff_8436_translate_offset(struct sfp_port_data *port_data,
+        loff_t *offset, struct i2c_client **client)
+{
+    unsigned page = 0;
+
+    *client = port_data->client;
+
+    /*
+     * if offset is in the range 0-128...
+     * page doesn't matter (using lower half), return 0.
+     * offset is already correct (don't add 128 to get to paged area)
+     */
+    if (*offset < SFF_8436_PAGE_SIZE)
+        return page;
+
+    /* note, page will always be positive since *offset >= 128 */
+    page = (*offset >> 7)-1;
+    /* 0x80 places the offset in the top half, offset is last 7 bits */
+    *offset = SFF_8436_PAGE_SIZE + (*offset & 0x7f);
+
+    return page;  /* note also returning client and offset */
+}
+
+static ssize_t sff_8436_eeprom_read(struct sfp_port_data *port_data,
+            struct i2c_client *client,
+            char *buf, unsigned offset, size_t count)
+{
+    struct i2c_msg msg[2];
+    u8 msgbuf[2];
+    unsigned long timeout, read_time;
+    int status, i;
+
+    memset(msg, 0, sizeof(msg));
+
+    switch (port_data->use_smbus) {
+    case I2C_SMBUS_I2C_BLOCK_DATA:
+        /*smaller eeproms can work given some SMBus extension calls */
+        if (count > I2C_SMBUS_BLOCK_MAX)
+            count = I2C_SMBUS_BLOCK_MAX;
+        break;
+    case I2C_SMBUS_WORD_DATA:
+        /* Check for odd length transaction */
+        count = (count == 1) ? 1 : 2;
+        break;
+    case I2C_SMBUS_BYTE_DATA:
+        count = 1;
+        break;
+    default:
+        /*
+         * When we have a better choice than SMBus calls, use a
+         * combined I2C message. Write address; then read up to
+         * io_limit data bytes.  msgbuf is u8 and will cast to our
+         * needs.
+         */
+        i = 0;
+        msgbuf[i++] = offset;
+
+        msg[0].addr = client->addr;
+        msg[0].buf = msgbuf;
+        msg[0].len = i;
+
+        msg[1].addr = client->addr;
+        msg[1].flags = I2C_M_RD;
+        msg[1].buf = buf;
+        msg[1].len = count;
+    }
+
+    /*
+     * Reads fail if the previous write didn't complete yet. We may
+     * loop a few times until this one succeeds, waiting at least
+     * long enough for one entire page write to work.
+     */
+    timeout = jiffies + msecs_to_jiffies(write_timeout);
+    do {
+        read_time = jiffies;
+
+        switch (port_data->use_smbus) {
+        case I2C_SMBUS_I2C_BLOCK_DATA:
+            status = i2c_smbus_read_i2c_block_data(client, offset,
+                    count, buf);
+            break;
+        case I2C_SMBUS_WORD_DATA:
+            status = i2c_smbus_read_word_data(client, offset);
+            if (status >= 0) {
+                buf[0] = status & 0xff;
+                if (count == 2)
+                    buf[1] = status >> 8;
+                status = count;
+            }
+            break;
+        case I2C_SMBUS_BYTE_DATA:
+            status = i2c_smbus_read_byte_data(client, offset);
+            if (status >= 0) {
+                buf[0] = status;
+                status = count;
+            }
+            break;
+        default:
+            status = i2c_transfer(client->adapter, msg, 2);
+            if (status == 2)
+                status = count;
+        }
+
+        dev_dbg(&client->dev, "eeprom read %zu@%d --> %d (%ld)\n",
+                count, offset, status, jiffies);
+
+        if (status == count)  /* happy path */
+            return count;
+
+        if (status == -ENXIO) /* no module present */
+            return status;
+
+        /* REVISIT: at HZ=100, this is sloooow */
+        msleep(1);
+    } while (time_before(read_time, timeout));
+
+    return -ETIMEDOUT;
+}
+
+static ssize_t sff_8436_eeprom_write(struct sfp_port_data *port_data,
+                    struct i2c_client *client,
+                const char *buf,
+                unsigned offset, size_t count)
+{
+    struct i2c_msg msg;
+    ssize_t status;
+    unsigned long timeout, write_time;
+    unsigned next_page_start;
+    int i = 0;
+
+    /* write max is at most a page
+     * (In this driver, write_max is actually one byte!)
+     */
+    if (count > port_data->write_max)
+        count = port_data->write_max;
+
+    /* shorten count if necessary to avoid crossing page boundary */
+    next_page_start = roundup(offset + 1, SFF_8436_PAGE_SIZE);
+    if (offset + count > next_page_start)
+        count = next_page_start - offset;
+
+    switch (port_data->use_smbus) {
+    case I2C_SMBUS_I2C_BLOCK_DATA:
+        /*smaller eeproms can work given some SMBus extension calls */
+        if (count > I2C_SMBUS_BLOCK_MAX)
+            count = I2C_SMBUS_BLOCK_MAX;
+        break;
+    case I2C_SMBUS_WORD_DATA:
+        /* Check for odd length transaction */
+        count = (count == 1) ? 1 : 2;
+        break;
+    case I2C_SMBUS_BYTE_DATA:
+        count = 1;
+        break;
+    default:
+        /* If we'll use I2C calls for I/O, set up the message */
+        msg.addr = client->addr;
+        msg.flags = 0;
+
+        /* msg.buf is u8 and casts will mask the values */
+        msg.buf = port_data->writebuf;
+
+        msg.buf[i++] = offset;
+        memcpy(&msg.buf[i], buf, count);
+        msg.len = i + count;
+        break;
+    }
+
+    /*
+     * Reads fail if the previous write didn't complete yet. We may
+     * loop a few times until this one succeeds, waiting at least
+     * long enough for one entire page write to work.
+     */
+    timeout = jiffies + msecs_to_jiffies(write_timeout);
+    do {
+        write_time = jiffies;
+
+        switch (port_data->use_smbus) {
+        case I2C_SMBUS_I2C_BLOCK_DATA:
+            status = i2c_smbus_write_i2c_block_data(client,
+                        offset, count, buf);
+            if (status == 0)
+                status = count;
+            break;
+        case I2C_SMBUS_WORD_DATA:
+            if (count == 2) {
+                status = i2c_smbus_write_word_data(client,
+                    offset, (u16)((buf[0])|(buf[1] << 8)));
+            } else {
+                /* count = 1 */
+                status = i2c_smbus_write_byte_data(client,
+                    offset, buf[0]);
+            }
+            if (status == 0)
+                status = count;
+            break;
+        case I2C_SMBUS_BYTE_DATA:
+            status = i2c_smbus_write_byte_data(client, offset,
+                        buf[0]);
+            if (status == 0)
+                status = count;
+            break;
+        default:
+            status = i2c_transfer(client->adapter, &msg, 1);
+            if (status == 1)
+                status = count;
+            break;
+        }
+
+        dev_dbg(&client->dev, "eeprom write %zu@%d --> %ld (%lu)\n",
+                count, offset, (long int) status, jiffies);
+
+        if (status == count)
+            return count;
+
+        /* REVISIT: at HZ=100, this is sloooow */
+        msleep(1);
+    } while (time_before(write_time, timeout));
+
+    return -ETIMEDOUT;
+}
+
+
+static ssize_t sff_8436_eeprom_update_client(struct sfp_port_data *port_data,
+                char *buf, loff_t off, 
+                size_t count, qsfp_opcode_e opcode)
+{
+    struct i2c_client *client;
+    ssize_t retval = 0;
+    u8 page = 0;
+    loff_t phy_offset = off;
+    int ret = 0;
+
+    page = sff_8436_translate_offset(port_data, &phy_offset, &client);
+
+    dev_dbg(&client->dev,
+            "sff_8436_eeprom_update_client off %lld  page:%d phy_offset:%lld, count:%ld, opcode:%d\n",
+            off, page, phy_offset, (long int) count, opcode);
+    if (page > 0) {
+        ret = sff_8436_eeprom_write(port_data, client, &page, 
+            SFF_8436_PAGE_SELECT_REG, 1);
+        if (ret < 0) {
+            dev_dbg(&client->dev,
+                "Write page register for page %d failed ret:%d!\n",
+                    page, ret);
+            return ret;
+        }
+        // Add sleep to avoid read error after change page.
+        msleep(1);
+    }
+
+    while (count) {
+        ssize_t    status;
+
+        if (opcode == QSFP_READ_OP) {
+            status =  sff_8436_eeprom_read(port_data, client,
+                buf, phy_offset, count);
+        } else {
+            status =  sff_8436_eeprom_write(port_data, client,
+                buf, phy_offset, count);
+        }
+        if (status <= 0) {
+            if (retval == 0)
+                retval = status;
+            break;
+        }
+        buf += status;
+        phy_offset += status;
+        count -= status;
+        retval += status;
+    }
+
+
+    if (page > 0) {
+        /* return the page register to page 0 (why?) */
+        page = 0;
+        ret = sff_8436_eeprom_write(port_data, client, &page, 
+            SFF_8436_PAGE_SELECT_REG, 1);
+        if (ret < 0) {
+            dev_err(&client->dev,
+                "Restore page register to page %d failed ret:%d!\n",
+                    page, ret);
+            return ret;
+        }
+        // Add sleep to avoid read error after change page.
+        msleep(1);
+    }
+    return retval;
+}
+
+
+/*
+ * Figure out if this access is within the range of supported pages.
+ * Note this is called on every access because we don't know if the
+ * module has been replaced since the last call.
+ * If/when modules support more pages, this is the routine to update
+ * to validate and allow access to additional pages.
+ *
+ * Returns updated len for this access:
+ *     - entire access is legal, original len is returned.
+ *     - access begins legal but is too long, len is truncated to fit.
+ *     - initial offset exceeds supported pages, return -EINVAL
+ */
+static ssize_t sff_8436_page_legal(struct sfp_port_data *port_data, 
+        loff_t off, size_t len)
+{
+    struct i2c_client *client = port_data->client;
+    u8 regval;
+    int status;
+    size_t maxlen;
+
+    if (off < 0) return -EINVAL;
+    if (port_data->driver_type == DRIVER_TYPE_SFP_MSA) {
+        /* SFP case */
+        /* if no pages needed, we're good */
+        if ((off + len) <= SFF_8472_EEPROM_UNPAGED_SIZE) return len;
+        /* if offset exceeds possible pages, we're not good */
+        if (off >= SFF_8472_EEPROM_SIZE) return -EINVAL;
+        /* in between, are pages supported? */
+        status = sff_8436_eeprom_read(port_data, client, &regval, 
+                SFF_8472_PAGEABLE_REG, 1);
+        if (status < 0) return status;  /* error out (no module?) */
+        if (regval & SFF_8472_PAGEABLE) {
+            /* Pages supported, trim len to the end of pages */
+            maxlen = SFF_8472_EEPROM_SIZE - off;
+        } else {
+            /* pages not supported, trim len to unpaged size */
+            maxlen = SFF_8472_EEPROM_UNPAGED_SIZE - off;
+        }
+        len = (len > maxlen) ? maxlen : len;
+        dev_dbg(&client->dev,
+            "page_legal, SFP, off %lld len %ld\n",
+            off, (long int) len);
+    } 
+    else if (port_data->driver_type == DRIVER_TYPE_QSFP ||
+             port_data->driver_type == DRIVER_TYPE_XFP) {
+        /* QSFP case */
+        /* if no pages needed, we're good */
+        if ((off + len) <= SFF_8436_EEPROM_UNPAGED_SIZE) return len;
+        /* if offset exceeds possible pages, we're not good */
+        if (off >= SFF_8436_EEPROM_SIZE) return -EINVAL;
+        /* in between, are pages supported? */
+        status = sff_8436_eeprom_read(port_data, client, &regval, 
+                SFF_8436_PAGEABLE_REG, 1);
+        if (status < 0) return status;  /* error out (no module?) */
+        if (regval & SFF_8436_NOT_PAGEABLE) {
+            /* pages not supported, trim len to unpaged size */
+            maxlen = SFF_8436_EEPROM_UNPAGED_SIZE - off;
+        } else {
+            /* Pages supported, trim len to the end of pages */
+            maxlen = SFF_8436_EEPROM_SIZE - off;
+        }
+        len = (len > maxlen) ? maxlen : len;
+        dev_dbg(&client->dev,
+            "page_legal, QSFP, off %lld len %ld\n",
+            off, (long int) len);
+    }
+    else {
+        return -EINVAL;
+    }
+    return len;
+}
+
+
+static ssize_t sfp_port_read_write(struct sfp_port_data *port_data,
+        char *buf, loff_t off, size_t len, qsfp_opcode_e opcode)
+{
+    struct i2c_client *client = port_data->client;
+    int chunk;
+    int status = 0;
+    ssize_t retval;
+    size_t pending_len = 0, chunk_len = 0;
+    loff_t chunk_offset = 0, chunk_start_offset = 0;
+
+    if (unlikely(!len))
+        return len;
+
+    /*
+     * Read data from chip, protecting against concurrent updates
+     * from this host, but not from other I2C masters.
+     */
+    mutex_lock(&port_data->update_lock);
+    
+    /*
+     * Confirm this access fits within the device suppored addr range 
+     */
+    len = sff_8436_page_legal(port_data, off, len);
+    if (len < 0) {
+        status = len;
+        goto err;
+    }
+
+    /*
+     * For each (128 byte) chunk involved in this request, issue a
+     * separate call to sff_eeprom_update_client(), to
+     * ensure that each access recalculates the client/page
+     * and writes the page register as needed.
+     * Note that chunk to page mapping is confusing, is different for 
+     * QSFP and SFP, and never needs to be done.  Don't try!
+     */
+    pending_len = len; /* amount remaining to transfer */
+    retval = 0;  /* amount transferred */
+    for (chunk = off >> 7; chunk <= (off + len - 1) >> 7; chunk++) {
+
+        /*
+         * Compute the offset and number of bytes to be read/write
+         *
+         * 1. start at offset 0 (within the chunk), and read/write
+         *    the entire chunk
+         * 2. start at offset 0 (within the chunk) and read/write less
+         *    than entire chunk
+         * 3. start at an offset not equal to 0 and read/write the rest
+         *    of the chunk
+         * 4. start at an offset not equal to 0 and read/write less than
+         *    (end of chunk - offset)
+         */
+        chunk_start_offset = chunk * SFF_8436_PAGE_SIZE;
+
+        if (chunk_start_offset < off) {
+            chunk_offset = off;
+            if ((off + pending_len) < (chunk_start_offset +
+                    SFF_8436_PAGE_SIZE))
+                chunk_len = pending_len;
+            else
+                chunk_len = (chunk+1)*SFF_8436_PAGE_SIZE - off;/*SFF_8436_PAGE_SIZE - off;*/
+        } else {
+            chunk_offset = chunk_start_offset;
+            if (pending_len > SFF_8436_PAGE_SIZE)
+                chunk_len = SFF_8436_PAGE_SIZE;
+            else
+                chunk_len = pending_len;
+        }
+
+        dev_dbg(&client->dev,
+            "sff_r/w: off %lld, len %ld, chunk_start_offset %lld, chunk_offset %lld, chunk_len %ld, pending_len %ld\n",
+            off, (long int) len, chunk_start_offset, chunk_offset,
+            (long int) chunk_len, (long int) pending_len);
+
+        /* 
+         * note: chunk_offset is from the start of the EEPROM, 
+         * not the start of the chunk 
+         */
+        status = sff_8436_eeprom_update_client(port_data, buf, 
+                chunk_offset, chunk_len, opcode);
+        if (status != chunk_len) {
+            /* This is another 'no device present' path */
+            dev_dbg(&client->dev, 
+    "sff_8436_update_client for chunk %d chunk_offset %lld chunk_len %ld failed %d!\n",
+                chunk, chunk_offset, (long int) chunk_len, status);
+            goto err;
+        }
+        buf += status;
+        pending_len -= status;
+        retval += status;
+    }
+    mutex_unlock(&port_data->update_lock);
+
+    return retval;
+
+err:
+    mutex_unlock(&port_data->update_lock);
+
+    return status;
+}
+
+#else
+static ssize_t sfp_port_read(struct sfp_port_data *data,
+                char *buf, loff_t off, size_t count)
+{
+    ssize_t retval = 0;
+
+    if (unlikely(!count)) {
+        DEBUG_PRINT("Count = 0, return");
+        return count;
+    }
+
+    /*
+     * Read data from chip, protecting against concurrent updates
+     * from this host, but not from other I2C masters.
+     */
+    mutex_lock(&data->update_lock);
+
+    while (count) {
+        ssize_t status;
+
+        status = sfp_eeprom_read(data->client, off, buf, count);
+        if (status <= 0) {
+            if (retval == 0) {
+                retval = status;
+            }
+            break;
+        }
+
+        buf += status;
+        off += status;
+        count -= status;
+        retval += status;
+    }
+
+    mutex_unlock(&data->update_lock);
+    return retval;
+
+}
+#endif
+
+static ssize_t sfp_bin_read(struct file *filp, struct kobject *kobj,
+        struct bin_attribute *attr,
+        char *buf, loff_t off, size_t count)
+{
+    int present;
+    struct sfp_port_data *data;
+    DEBUG_PRINT("offset = (%d), count = (%d)", off, count);
+    
+    data = dev_get_drvdata(container_of(kobj, struct device, kobj));
+    present = sfp_is_port_present(data->client, data->port);
+    if (present < 0) {
+        return present;
+    }
+
+    if (present == 0) {
+        /* port is not present */
+        return -ENODEV;
+    }
+
+#if (MULTIPAGE_SUPPORT == 1)
+    return sfp_port_read_write(data, buf, off, count, QSFP_READ_OP);
+#else
+    return sfp_port_read(data, buf, off, count);
+#endif
+}
+
+#if (MULTIPAGE_SUPPORT == 1)
+static int sfp_sysfs_eeprom_init(struct kobject *kobj, struct bin_attribute *eeprom, size_t size)
+#else
+static int sfp_sysfs_eeprom_init(struct kobject *kobj, struct bin_attribute *eeprom)
+#endif
+{
+    int err;
+
+    sysfs_bin_attr_init(eeprom);
+    eeprom->attr.name = EEPROM_NAME;
+    eeprom->attr.mode = S_IWUSR | S_IRUGO;
+    eeprom->read      = sfp_bin_read;
+    eeprom->write      = sfp_bin_write;
+#if (MULTIPAGE_SUPPORT == 1)
+    eeprom->size      = size;
+#else
+    eeprom->size      = EEPROM_SIZE;
+#endif
+
+    /* Create eeprom file */
+    err = sysfs_create_bin_file(kobj, eeprom);
+    if (err) {
+        return err;
+    }
+
+    return 0;
+}
+
+static int sfp_sysfs_eeprom_cleanup(struct kobject *kobj, struct bin_attribute *eeprom)
+{
+    sysfs_remove_bin_file(kobj, eeprom);
+    return 0;
+}
+
+
+#if (MULTIPAGE_SUPPORT == 0)
+static int sfp_i2c_check_functionality(struct i2c_client *client)
+{
+#if USE_I2C_BLOCK_READ
+    return i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_I2C_BLOCK);
+#else
+    return i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA);
+#endif
+}
+#endif
+
+static const struct attribute_group sfp_msa_group = {
+    .attrs = sfp_msa_attributes,
+};
+
+static const struct attribute_group qsfp_group = {
+    .attrs = qsfp_attributes,
+};
+
+static int qsfp_probe(struct i2c_client *client, const struct i2c_device_id *dev_id,
+                          struct qsfp_data **data)
+{
+    int status;
+    struct qsfp_data *qsfp;
+
+#if (MULTIPAGE_SUPPORT == 0)
+    if (!sfp_i2c_check_functionality(client)) {
+        status = -EIO;
+        goto exit;
+    }
+#endif
+
+    qsfp = kzalloc(sizeof(struct qsfp_data), GFP_KERNEL);
+    if (!qsfp) {
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    /* Register sysfs hooks */
+    status = sysfs_create_group(&client->dev.kobj, &qsfp_group);
+    if (status) {
+        goto exit_free;
+    }
+
+    /* init eeprom */
+#if (MULTIPAGE_SUPPORT == 1)
+    status = sfp_sysfs_eeprom_init(&client->dev.kobj, &qsfp->eeprom.bin, SFF_8436_EEPROM_SIZE);
+#else
+    status = sfp_sysfs_eeprom_init(&client->dev.kobj, &qsfp->eeprom.bin);
+#endif
+    if (status) {
+        goto exit_remove;
+    }
+
+    *data = qsfp;
+    dev_dbg(&client->dev, "qsfp '%s'\n", client->name);
+
+    return 0;
+
+exit_remove:
+    sysfs_remove_group(&client->dev.kobj, &qsfp_group);
+exit_free:
+    kfree(qsfp);
+exit:
+
+    return status;
+}
+
+/* Platform dependent +++ */
+static int sfp_device_probe(struct i2c_client *client,
+            const struct i2c_device_id *dev_id)
+{
+    int ret = 0;
+    struct sfp_port_data *data = NULL;
+
+    if (client->addr != SFP_EEPROM_A0_I2C_ADDR) {
+        return -ENODEV;
+    }
+
+    if (dev_id->driver_data < csp7551_port1 || dev_id->driver_data > csp7551_port32) {
+        return -ENXIO;
+    }
+
+    data = kzalloc(sizeof(struct sfp_port_data), GFP_KERNEL);
+    if (!data) {
+        return -ENOMEM;
+    }
+
+#if (MULTIPAGE_SUPPORT == 1)
+    data->use_smbus = 0;
+
+    /* Use I2C operations unless we're stuck with SMBus extensions. */
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
+        if (i2c_check_functionality(client->adapter,
+                I2C_FUNC_SMBUS_READ_I2C_BLOCK)) {
+            data->use_smbus = I2C_SMBUS_I2C_BLOCK_DATA;
+        } else if (i2c_check_functionality(client->adapter,
+                I2C_FUNC_SMBUS_READ_WORD_DATA)) {
+            data->use_smbus = I2C_SMBUS_WORD_DATA;
+        } else if (i2c_check_functionality(client->adapter,
+                I2C_FUNC_SMBUS_READ_BYTE_DATA)) {
+            data->use_smbus = I2C_SMBUS_BYTE_DATA;
+        } else {
+            ret = -EPFNOSUPPORT;
+            goto exit_kfree;
+        }
+    }
+
+    if (!data->use_smbus ||
+            (i2c_check_functionality(client->adapter,
+                I2C_FUNC_SMBUS_WRITE_I2C_BLOCK)) ||
+            i2c_check_functionality(client->adapter,
+                I2C_FUNC_SMBUS_WRITE_WORD_DATA) ||
+            i2c_check_functionality(client->adapter,
+                I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
+        /*
+         * NOTE: AN-2079
+         * Finisar recommends that the host implement 1 byte writes
+         * only since this module only supports 32 byte page boundaries.
+         * 2 byte writes are acceptable for PE and Vout changes per
+         * Application Note AN-2071.
+         */
+        unsigned write_max = 1;
+
+        if (write_max > io_limit)
+            write_max = io_limit;
+        if (data->use_smbus && write_max > I2C_SMBUS_BLOCK_MAX)
+            write_max = I2C_SMBUS_BLOCK_MAX;
+        data->write_max = write_max;
+
+        /* buffer (data + address at the beginning) */
+        data->writebuf = kmalloc(write_max + 2, GFP_KERNEL);
+        if (!data->writebuf) {
+            ret = -ENOMEM;
+            goto exit_kfree;
+        }
+    } else {
+            dev_warn(&client->dev,
+                "cannot write due to controller restrictions.");
+    }
+#if 0 // Wishbone not support I2C_SMBUS_I2C_BLOCK_DATA
+    if (data->use_smbus == I2C_SMBUS_WORD_DATA ||
+        data->use_smbus == I2C_SMBUS_BYTE_DATA) {
+        dev_notice(&client->dev, "Falling back to %s reads, "
+               "performance will suffer\n", data->use_smbus ==
+               I2C_SMBUS_WORD_DATA ? "word" : "byte");
+    }
+#endif
+#endif
+
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+    data->port = dev_id->driver_data;
+    data->client = client;
+    /* port qsfp1 ~ port qsfp32 */
+    if (dev_id->driver_data >= csp7551_port1 && dev_id->driver_data <= csp7551_port32) {
+        data->driver_type = DRIVER_TYPE_QSFP;
+        ret = qsfp_probe(client, dev_id, &data->qsfp);
+    }
+    else {
+        ret = -1;
+    }
+
+    if (ret < 0) {
+        goto exit_kfree_buf;
+    }
+
+    return ret;
+
+exit_kfree_buf:
+#if (MULTIPAGE_SUPPORT == 1)
+    if (data->writebuf) kfree(data->writebuf);
+#endif
+
+exit_kfree:
+    kfree(data);
+    return ret;
+}
+/* Platform dependent --- */
+
+static int sfp_msa_remove(struct i2c_client *client, struct sfp_msa_data *data)
+{
+    sfp_sysfs_eeprom_cleanup(&client->dev.kobj, &data->eeprom.bin);
+#if (MULTIPAGE_SUPPORT == 1)
+    i2c_unregister_device(data->ddm_client);
+#endif
+    sysfs_remove_group(&client->dev.kobj, &sfp_msa_group);
+    kfree(data);
+    return 0;
+}
+
+static int qsfp_remove(struct i2c_client *client, struct qsfp_data *data)
+{
+    sfp_sysfs_eeprom_cleanup(&client->dev.kobj, &data->eeprom.bin);
+    sysfs_remove_group(&client->dev.kobj, &qsfp_group);
+    kfree(data);
+    return 0;
+}
+
+static int sfp_device_remove(struct i2c_client *client)
+{
+    int ret = 0;
+    struct sfp_port_data *data = i2c_get_clientdata(client);
+
+    switch (data->driver_type) {
+        case DRIVER_TYPE_SFP_MSA:
+            return sfp_msa_remove(client, data->msa);
+        case DRIVER_TYPE_QSFP:
+            return qsfp_remove(client, data->qsfp);
+        default:
+            return qsfp_remove(client, data->qsfp);
+    }
+
+#if (MULTIPAGE_SUPPORT == 1)
+    if (data->writebuf)
+        kfree(data->writebuf);
+#endif
+    kfree(data);
+    return ret;
+}
+
+/* Addresses scanned
+ */
+static const unsigned short normal_i2c[] = { I2C_CLIENT_END };
+
+static struct i2c_driver sfp_driver = {
+    .driver = {
+        .name       = DRIVER_NAME,
+    },
+    .probe          = sfp_device_probe,
+    .remove         = sfp_device_remove,
+    .id_table       = sfp_device_id,
+    .address_list   = normal_i2c,
+};
+
+static int __init sfp_init(void)
+{
+    return i2c_add_driver(&sfp_driver);
+}
+
+static void __exit sfp_exit(void)
+{
+    i2c_del_driver(&sfp_driver);
+}
+
+MODULE_AUTHOR("Will Chen <will_chen@accton.com.tw>");
+MODULE_DESCRIPTION("accton csp7551_sfp driver");
+MODULE_LICENSE("GPL");
+MODULE_VERSION("0.0.6");
+
+module_init(sfp_init);
+module_exit(sfp_exit);
+

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -5,6 +5,7 @@
 #  SPDX-License-Identifier:     GPL-2.0
 
 BISDN_LINUX_VOLUME_LABEL="BISDN-Linux"
+BISDN_LINUX_VOLUME_SIZE_MB=6144
 
 set -e
 
@@ -315,7 +316,7 @@ onl_baseplatform="${onl_platform%-r*}"
 echo "BISDN Linux Installer"
 
 # part_size: BISDN Linux partition in MB
-part_size=6144
+part_size=$BISDN_LINUX_VOLUME_SIZE_MB
 fs_type="ext4"
 
 # platform_check, if implemented, aborts with an error if the hardware platform

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -271,6 +271,11 @@ platform_install_bootloader_entry()
     /bin/true
 }
 
+platform_setup()
+{
+    /bin/true
+}
+
 onie_platform=$(onie-sysinfo -p)
 
 cd $(dirname $0)
@@ -452,6 +457,8 @@ if [ ! -f "$bisdn_linux_mnt/etc/hostname" ]; then
     echo $hostname > "$bisdn_linux_mnt/etc/hostname"
     echo "127.0.1.1 $hostname" >> "$bisdn_linux_mnt/etc/hosts"
 fi
+
+platform_setup
 
 # Restore the network configuration from previous installation
 if [ "${DO_RESTORE}" = true ]; then

--- a/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
+++ b/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
@@ -1,0 +1,3 @@
+GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200n8"
+GRUB_SERIAL_COMMAND="serial --port=0x3f8 --speed=115200 --word=8 --parity=no --stop=1"
+EXTRA_CMDLINE_LINUX=""

--- a/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
+++ b/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
@@ -1,6 +1,7 @@
 GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200n8"
 GRUB_SERIAL_COMMAND="serial --port=0x3f8 --speed=115200 --word=8 --parity=no --stop=1"
 EXTRA_CMDLINE_LINUX=""
+BISDN_LINUX_VOLUME_SIZE_MB=163840
 
 platform_setup() {
     (cat <<EOF

--- a/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
+++ b/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
@@ -1,3 +1,25 @@
 GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200n8"
 GRUB_SERIAL_COMMAND="serial --port=0x3f8 --speed=115200 --word=8 --parity=no --stop=1"
 EXTRA_CMDLINE_LINUX=""
+
+platform_setup() {
+    (cat <<EOF
+[Match]
+Path=pci-0000:18:00.0
+
+[Link]
+Description=Tofino ICE CPU port #0 (Intel Ethernet Connection E800)
+Name=bf_ice0
+EOF
+    ) > "$bisdn_linux_mnt/lib/systemd/network/10-bf_ice0.link"
+
+    (cat <<EOF
+[Match]
+Path=pci-0000:86:00.0
+
+[Link]
+Description=Tofino ICE CPU port #1 (Intel Ethernet Connection E800)
+Name=bf_ice1
+EOF
+    ) > "$bisdn_linux_mnt/lib/systemd/network/10-bf_ice1.link"
+}

--- a/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
+++ b/scripts/installer/machine/x86_64-accton_csp7551-r0/platform.conf
@@ -22,4 +22,16 @@ Description=Tofino ICE CPU port #1 (Intel Ethernet Connection E800)
 Name=bf_ice1
 EOF
     ) > "$bisdn_linux_mnt/lib/systemd/network/10-bf_ice1.link"
+
+    (cat <<EOF
+[Match]
+# Identify "Barefoot Networks, Inc. Tofino 1"
+# We cannot use the PCI path because it is not the same for all CSP7551.
+Property=ID_VENDOR_ID=0x1d1c ID_MODEL_ID=0x0010
+
+[Link]
+Description=Tofino PCI CPU port
+# This file exists solely to keep user-space from renaming the interface.
+EOF
+    ) > "$bisdn_linux_mnt/lib/systemd/network/10-bf_pci0.link"
 }


### PR DESCRIPTION
This PR adds code and configuration specific to the Accton CSP7551. Most notably, it adds platform drivers (cpld, sfp, fpga). It also contains a platform initialization script, creates configuration files for the network ports giving the CPU access to the Tofino chip, and increases the partition created for BISDN Linux from 6 GB to 160 GB.