### PR TITLE
distro: disable seccomp in docker-ce again

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -33,3 +33,6 @@ DISTRO_FEATURES:remove = "alsa"
 
 # disable symlinking of /var/volatile to /var/log to enable persistent logs
 VOLATILE_LOG_DIR = "no"
+
+# we do not have seccomp in DISTRO_FEATURES, so do not enable it for docker
+PACKAGECONFIG:pn-docker-ce ?= "docker-init"


### PR DESCRIPTION
meta-virtualization enabled the seccomp feature for docker-ce with 51833d0e1311 ("docker: add seccomp to default packageconfig settings"), but we do not have seccomp enabled in our builds, breaking it due to inresolved dependencies.

To restore the old state, restore the packageconf to its previous state without seccomp.

Fixes the following build error:

    ERROR: Nothing PROVIDES 'libseccomp' (but .../poky/meta-virtualization/recipes-containers/docker/docker-ce_git.bb DEPENDS on or otherwise requires it)
    libseccomp was skipped: missing required distro feature 'seccomp' (not in DISTRO_FEATURES)
    ERROR: Required build target 'docker-ce' has no buildable providers.
    Missing or unbuildable dependency chain was: ['docker-ce', 'libseccomp']

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>