### PR TITLE
Remove NFS, disable LLMNR and block ports 5000, 6653 and 50051 from the data-plane

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -18,7 +18,7 @@ FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
 FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/master/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile nfs pci pcmcia systemd usbgadget usbhost virtualization xattr"
+DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci pcmcia systemd usbgadget usbhost virtualization xattr"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"

--- a/recipes-core/systemd/files/10-disable-llmnr.conf
+++ b/recipes-core/systemd/files/10-disable-llmnr.conf
@@ -1,0 +1,2 @@
+[Resolve]
+LLMNR=no

--- a/recipes-core/systemd/systemd.inc
+++ b/recipes-core/systemd/systemd.inc
@@ -5,11 +5,13 @@ PACKAGECONFIG:append = " coredump networkd resolved"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
-    file://20-network-io.conf \
     file://10-any_interface_is_enough.conf \
+    file://10-disable-llmnr.conf \
+    file://20-network-io.conf \
 "
 
 FILES:${PN} += "\
+    ${sysconfdir}/systemd/resolved.conf.d/10-disable-llmnr.conf \
     ${sysconfdir}/sysctl.d/20-network-io.conf \
 "
 
@@ -21,6 +23,10 @@ do_install:append() {
    # systemd-networkd-wait-online
    install -d ${D}${systemd_system_unitdir}/systemd-networkd-wait-online.service.d/
    install -m 0644 ${WORKDIR}/10-any_interface_is_enough.conf ${D}${systemd_system_unitdir}/systemd-networkd-wait-online.service.d/10-any_interface_is_enough.conf
+
+   # systemd-resolvd disable llmnr
+   install -d ${D}${sysconfdir}/systemd/resolved.conf.d/
+   install -m 0644 ${WORKDIR}/10-disable-llmnr.conf ${D}${sysconfdir}/systemd/resolved.conf.d/10-disable-llmnr.conf
 }
 
 USERADD_PARAM:${PN} += "--system --home /dev/null systemd-journal-gateway"

--- a/recipes-extended/iptables/iptables/ip6tables.rules
+++ b/recipes-extended/iptables/iptables/ip6tables.rules
@@ -1,3 +1,20 @@
 *filter
+# Whitelist loopback, as other rules only allow enp* ports
+-A INPUT -i lo -p tcp -m tcp -j ACCEPT
+-A INPUT -i lo -p udp -m udp -j ACCEPT
+
+# Allow established connections from all ports
+-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# Allow SSH from management port(s) enp* only
 -A INPUT ! -i enp+ -p tcp -m tcp --dport 22 -j DROP
+
+# Allow baseboxd port counters gRPC server port access only on management port(s) enp*
+-A INPUT ! -i enp+ -p tcp -m tcp --dport 5000 -j DROP
+
+# Allow baseboxd OpenFlow controller port only from management port(s) enp*
+-A INPUT ! -i enp+ -p tcp -m tcp --dport 6653 -j DROP
+
+# Allow ofdpa-grpc gRPC server port connections only on management port(s) enp*
+-A INPUT ! -i enp+ -p tcp -m tcp --dport 50051 -j DROP
 COMMIT

--- a/recipes-extended/iptables/iptables/iptables.rules
+++ b/recipes-extended/iptables/iptables/iptables.rules
@@ -1,3 +1,20 @@
 *filter
+# Whitelist loopback, as other rules only allow enp* ports
+-A INPUT -i lo -p tcp -m tcp -j ACCEPT
+-A INPUT -i lo -p udp -m udp -j ACCEPT
+
+# Allow established connections from all ports
+-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# Allow SSH from management port(s) enp* only
 -A INPUT ! -i enp+ -p tcp -m tcp --dport 22 -j DROP
+
+# Allow baseboxd port counters gRPC server port access only on management port(s) enp*
+-A INPUT ! -i enp+ -p tcp -m tcp --dport 5000 -j DROP
+
+# Allow baseboxd OpenFlow controller port only from management port(s) enp*
+-A INPUT ! -i enp+ -p tcp -m tcp --dport 6653 -j DROP
+
+# Allow ofdpa-grpc gRPC server port connections only on management port(s) enp*
+-A INPUT ! -i enp+ -p tcp -m tcp --dport 50051 -j DROP
 COMMIT


### PR DESCRIPTION
Issue #130 highlights the issue of the control plane ports being accessible from the data ports by default.

This blocks all incoming TCP/UDP connections from the dataplane to management ports. 