### PR TITLE
grpc: update append for v1.46.6

### DIFF
--- a/recipes-devtools/grpc/files/1.46.6/0001-CMakelists.txt-allow-building-the-grpc_cli-utility-o.patch
+++ b/recipes-devtools/grpc/files/1.46.6/0001-CMakelists.txt-allow-building-the-grpc_cli-utility-o.patch
@@ -1,4 +1,4 @@
-From 4127c47221cd13ae9462957b4f8396cdd36b2ff4 Mon Sep 17 00:00:00 2001
+From b5a15385fc6590f05b5c7557495b1dd52af4fe28 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 15 Jun 2022 17:45:38 +0200
 Subject: [PATCH] CMakelists.txt: allow building the grpc_cli utility only
@@ -9,10 +9,10 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 17 insertions(+), 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f3b66c074f1d..2c22ee898427 100644
+index df8c3c3dd7ac..f3b1c79e18ba 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -3553,7 +3553,7 @@ foreach(_hdr
+@@ -3423,7 +3423,7 @@ foreach(_hdr
  endforeach()
  
  endif()
@@ -21,7 +21,7 @@ index f3b66c074f1d..2c22ee898427 100644
  
  add_library(grpc++_test_config
    test/cpp/util/test_config_cc.cc
-@@ -3600,6 +3600,14 @@ target_link_libraries(grpc++_test_config
+@@ -3470,6 +3470,14 @@ target_link_libraries(grpc++_test_config
    gpr
  )
  
@@ -36,7 +36,7 @@ index f3b66c074f1d..2c22ee898427 100644
  
  endif()
  if(gRPC_BUILD_TESTS)
-@@ -10968,7 +10976,7 @@ target_link_libraries(grpc_authz_end2end_test
+@@ -10864,7 +10872,7 @@ target_link_libraries(grpc_authz_end2end_test
  
  
  endif()
@@ -45,7 +45,7 @@ index f3b66c074f1d..2c22ee898427 100644
  
  add_executable(grpc_cli
    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1alpha/reflection.pb.cc
-@@ -11013,6 +11021,13 @@ target_link_libraries(grpc_cli
+@@ -10909,6 +10917,13 @@ target_link_libraries(grpc_cli
    grpc++_test_config
  )
  
@@ -60,5 +60,5 @@ index f3b66c074f1d..2c22ee898427 100644
  endif()
  if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_CPP_PLUGIN)
 -- 
-2.36.1
+2.39.1
 

--- a/recipes-devtools/grpc/grpc_1.46.6.bbappend
+++ b/recipes-devtools/grpc/grpc_1.46.6.bbappend
@@ -8,7 +8,7 @@ SRCREV_gtest = "0e402173c97aea7a00749e825b194bfede4f2e45"
 
 SRC_URI:append = " \
            git://github.com/google/googletest.git;protocol=https;name=gtest;destsuffix=git/third_party/googletest;branch=main \
-           file://1.45.2/0001-CMakelists.txt-allow-building-the-grpc_cli-utility-o.patch \
+           file://1.46.6/0001-CMakelists.txt-allow-building-the-grpc_cli-utility-o.patch \
 "
 
 # build grpc_cli as well


### PR DESCRIPTION
meta-openembedded updated grpc to v1.46.6 with 06fb36d33cb3 ("grpc: upgrade 1.45.2 -> 1.46.6") to fix zlib CVE CVE-2022-37434, so we need to update our bbappend accordingly.

The googletest submodule was not updated between these versions, so only the patch needed a refresh.


Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>