### PR TITLE
base-files: do not backup /etc/modprobe.d/i2c-ismt.conf

### DIFF
--- a/recipes-core/base-files/base-files/system-backup.txt
+++ b/recipes-core/base-files/base-files/system-backup.txt
@@ -7,6 +7,7 @@
 /etc/sudoers.d
 /etc/systemd/network/
 /etc/ofdpa-grpc.conf
+-/etc/modprobe.d/i2c-ismt.conf
 -/etc/opkg/base-feeds.conf
 -/etc/opkg/arch.conf
 -/etc/opkg/opkg.conf


### PR DESCRIPTION
i2c-ismt is expected to be autoprobed on releases 4.8.x and earlier, but
master has it blacklisted via /etc/modprobe.d/i2c-ismt.conf.

Since Yocto treats it as a configuration file, it gets backed up when
upgrading, which can break the system when going back from
master/nightly to a previous release.

To avoid this happening, explicitly drop the file from backups.