### PR TITLE
distro: update FEEDURIPREFIX from master to main

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -15,7 +15,7 @@ DISTROOVERRIDES = "poky:bisdn-linux"
 EXTRAOPKGCONFIG   = "b-isdn-feed-config-opkg"
 
 FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
-FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/master/packages_latest-build"
+FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/main/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
 DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci pcmcia systemd usbgadget usbhost virtualization xattr"


### PR DESCRIPTION
Now that the default branch is main, the path where nightly builds appear will also change, so we need to update the FEEDURIPREFIX to point to the new location.