### PR TITLE
bundle-debug-info: dereference all symlinks while archiving

### DIFF
--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -350,7 +350,7 @@ fi
 
 title "Creating tarball"
 FILE="/tmp/support-data_$(date "+%Y%m%d-%H%M%S").tgz"
-tar czf "$FILE" -C "$TMPDIR" .
+tar czhf "$FILE" -C "$TMPDIR" .
 
 echo "Tarball created: $FILE"
 echo "Please send the tarball to support@bisdn.freshdesk.com"


### PR DESCRIPTION
* to avoid getting a bunch of symlinks in the debug bundle, we should make sure to dereference them while taring