### PR TITLE
images: full: remove redundant bde kernel modules

### DIFF
--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -21,8 +21,6 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     iptables \
     jq \
     keepalived \
-    kernel-module-linux-kernel-bde \
-    kernel-module-linux-user-bde \
     less \
     lmsensors-fancontrol \
     lmsensors-pwmconfig \


### PR DESCRIPTION
Both kernel-module-linux-kernel-bde and kernel-module-linux-user-bde are pulled in by the ofdpa package already. There is no need to have them in BISDN_SWITCH_IMAGE_EXTRA_INSTALL.