### PR TITLE
mstpd: use upstream version in recipe

### DIFF
--- a/recipes-support/mstpd/mstpd_0.1.0.bb
+++ b/recipes-support/mstpd/mstpd_0.1.0.bb
@@ -7,7 +7,7 @@ SRC_URI = "\
   git://github.com/bisdn/mstpd.git;branch=0.1.0+bisdn4;protocol=https \
   file://bridge-stp.conf"
 
-PV = "0.1.0+bisdn4"
+PV:append = "+bisdn4"
 SRCREV = "79402ba4763c99d4ccbae0406930bf4f979662c6"
 
 S = "${WORKDIR}/git"

--- a/recipes-support/mstpd/mstpd_0.1.0.bb
+++ b/recipes-support/mstpd/mstpd_0.1.0.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4325afd396febcb659c36b49533135d4"
 
 SRC_URI = "\
-  git://github.com/bisdn/mstpd.git;branch=0.1.0+bisdn4;protocol=https \
+  git://github.com/bisdn/mstpd.git;branch=${PV};protocol=https \
   file://bridge-stp.conf"
 
 PV:append = "+bisdn4"


### PR DESCRIPTION
Since we are basing our build on the 0.1.0 release and not a random git commit, let the recipe reflect that, and append our own version to `PV` instead.

While doing that, use that PV as the branch name, as we name our branches after them.

