### PR TITLE
onie-tools: user proper interface on u-boot for kernel arguments

### DIFF
--- a/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
+++ b/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
@@ -77,11 +77,12 @@ fi
 
 if [ -f /etc/fw_env.config ]; then
   if [[ -n "${IP}" && "${IP}" != "dhcp" ]]; then
-    boot_reason="install ip=${IP} install_url=${INSTALL_FILE}"
+    debugargs="ip=${IP} install_url=${INSTALL_FILE}"
   else
-    boot_reason="install install_url=${INSTALL_FILE}"
+    debugargs="install_url=${INSTALL_FILE}"
   fi
-  fw_setenv onie_boot_reason "$boot_reason"
+  fw_setenv onie_debugargs "$debugargs"
+  fw_setenv onie_boot_reason "install"
 else
   MNT_DIR="/mnt/onie-boot"
   mountpoint -q ${MNT_DIR} || mount ${MNT_DIR}


### PR DESCRIPTION
According to the ONIE Design specification[1], kernel arguments for ONIE are supposed to be passed via the U-Boot environment variable 'onie_debugargs', so let's do that instead of relying on U-Boot not quoting variables.

[1] https://opencomputeproject.github.io/onie/design-spec/uboot_nos_interface.html#u-boot-platform-adding-kernel-command-arguments

Fixes: 1e27d475ea45 ("onie-tools: add support for u-boot-arch based devices")