### PR TITLE
mstpd: do not try to read beyond the end of vlan messages

### DIFF
--- a/recipes-support/mstpd/mstpd_0.1.0.bb
+++ b/recipes-support/mstpd/mstpd_0.1.0.bb
@@ -7,8 +7,8 @@ SRC_URI = "\
   git://github.com/bisdn/mstpd.git;branch=${PV};protocol=https \
   file://bridge-stp.conf"
 
-PV:append = "+bisdn4"
-SRCREV = "79402ba4763c99d4ccbae0406930bf4f979662c6"
+PV:append = "+bisdn5"
+SRCREV = "ab12e96c5e459f976f7c86051792af735e4dde0f"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Since we skip the header, we also need to substract it from the data length, else we will read beyond the bridge vlan message.

Fixes: 9d1f4bb92dcb ("mstpd: replace naive driver_dep with proper per vlan state setting")