### PR TITLE
add a packagegroup for defining downloadable packages

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
+++ b/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Packagegroup for specifying installable packages for BISDN Linux"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHCKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+inherit packagegroup
+
+# optional packages as dependencies of this package to allow easy building
+RDEPENDS:${PN} = "\
+"

--- a/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
+++ b/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
@@ -9,3 +9,10 @@ RDEPENDS:${PN} = "\
     rp-pppoe \
     rp-pppoe-server \
 "
+
+# utilities useful for debugging (zstd to extract coredumps)
+RDEPENDS:${PN} += "\
+    gdb \
+    strace \
+    zstd \
+"

--- a/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
+++ b/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
@@ -6,4 +6,6 @@ inherit packagegroup
 
 # optional packages as dependencies of this package to allow easy building
 RDEPENDS:${PN} = "\
+    rp-pppoe \
+    rp-pppoe-server \
 "


### PR DESCRIPTION
To allow easily building and maintaining a list of packages to provide for releases, create a packagegroup that will depend on all packages that we want to provide as downloadable packages.

For now just define a single packagegroup to be targeted as an extra package to be build, which in turn (r)depends on all packages we want to provide as extra packages.