### PR TITLE
python3-ryu: add CVE_PRODUCT for CVE reporting

### DIFF
--- a/recipes-devtools/python/python3-ryu_git.bb
+++ b/recipes-devtools/python/python3-ryu_git.bb
@@ -4,6 +4,8 @@ SECTION = "devel/python"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
+CVE_PRODUCT = "facuet:ryu"
+
 PV = "4.34+git${SRCPV}"
 PR = "r1"
 SRCREV = "c776e4cb68600b2ee0a4f38364f4a355502777f1"


### PR DESCRIPTION
Add the correct CVE_PRODUCT name so cve check can scan for vulnerabilites.