### PR TITLE
drop explicit onl package include from image

### DIFF
--- a/conf/machine/accton-csp7551.conf
+++ b/conf/machine/accton-csp7551.conf
@@ -24,7 +24,6 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL:remove = " \
     ofdpa \
     ofdpa-grpc \
     ofdpa-tools \
-    onl \
     python3-ofdpa \
 "
 

--- a/recipes-core/images/minimal.bb
+++ b/recipes-core/images/minimal.bb
@@ -17,7 +17,6 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL = "\
     kernel-modules \
     less \
     onie-tools \
-    onl \
     openssh-sftp \
     openssh-sftp-server \
     parted \


### PR DESCRIPTION
Now that the machines depend on onl themselves, there is no need to explicitly include it anymore.