### PR TITLE
packagegroup-bisdn-linux-extra: add packages from CSP7551

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
+++ b/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
@@ -6,8 +6,14 @@ inherit packagegroup
 
 # optional packages as dependencies of this package to allow easy building
 RDEPENDS:${PN} = "\
+    fping \
+    iperf3 \
+    ipmitool \
+    net-tools \
+    openvswitch \
     rp-pppoe \
     rp-pppoe-server \
+    screen \
 "
 
 # utilities useful for debugging (zstd to extract coredumps)


### PR DESCRIPTION
Add useful packages that are currently installed with the Accton CSP7551 image to the list of packages that are built as optional downloads for all platforms.

Keep them in the CSP7551 image at least for now -- removing them will require tweaks to downstream processes.