### PR TITLE
base-files: back up additional files

### DIFF
--- a/recipes-core/base-files/base-files/system-backup.txt
+++ b/recipes-core/base-files/base-files/system-backup.txt
@@ -5,6 +5,8 @@
 /etc/group
 /etc/gshadow
 /etc/sudoers.d
+/etc/hostname
+/etc/hosts
 /etc/systemd/network/
 /etc/ofdpa-grpc.conf
 -/etc/modprobe.d/i2c-i801.conf

--- a/recipes-core/base-files/base-files/system-backup.txt
+++ b/recipes-core/base-files/base-files/system-backup.txt
@@ -8,6 +8,12 @@
 /etc/hostname
 /etc/hosts
 /etc/systemd/network/
+/etc/ssh/ssh_host_ecdsa_key
+/etc/ssh/ssh_host_ecdsa_key.pub
+/etc/ssh/ssh_host_ed25519_key
+/etc/ssh/ssh_host_ed25519_key.pub
+/etc/ssh/ssh_host_rsa_key
+/etc/ssh/ssh_host_rsa_key.pub
 /etc/ofdpa-grpc.conf
 -/etc/modprobe.d/i2c-i801.conf
 -/etc/modprobe.d/i2c-ismt.conf


### PR DESCRIPTION
This PR add a few additional entries to the list of files that are backed up and restored during an operating system upgrade: /etc/hostname, /etc/hosts, and the ssh host keys.