### PR TITLE
bisdn-feed-config-opkg: do not mark files as CONFFILES

### DIFF
--- a/recipes-core/base-files/base-files/system-backup.txt
+++ b/recipes-core/base-files/base-files/system-backup.txt
@@ -9,6 +9,4 @@
 /etc/ofdpa-grpc.conf
 -/etc/modprobe.d/i2c-i801.conf
 -/etc/modprobe.d/i2c-ismt.conf
--/etc/opkg/base-feeds.conf
--/etc/opkg/arch.conf
 -/etc/opkg/opkg.conf

--- a/recipes-core/feed-config/b-isdn-feed-config-opkg_1.0.bb
+++ b/recipes-core/feed-config/b-isdn-feed-config-opkg_1.0.bb
@@ -41,7 +41,3 @@ do_install () {
 }
 
 FILES:${PN} = "${sysconfdir}/opkg/ "
-
-CONFFILES:${PN} += "${sysconfdir}/opkg/base-feeds.conf \
-                    ${sysconfdir}/opkg/arch.conf"
-


### PR DESCRIPTION
bisdn-feed-config-opkg marks /etc/opkg/base-feeds.conf and /etc/opkg/arch.conf as configuration files, which we then later prevent from being backed up via system-backup.txt.

So let's just not mark them as configuration files, then we don't need to remove them from the backup later.