### PR TITLE
onie-tools: allow predownloading to localfs for upgrades

### DIFF
--- a/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
+++ b/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
@@ -10,6 +10,7 @@ usage: $(basename "$0") [OPTIONS] [IMAGEURL]
 
 [OPTIONS]
 -h show this message
+-d download image and use localfs discovery for installation
 -y automatically answer yes to all questions (use with caution, system is going to reboot and configuration files might get lost)
 
 [IMAGEURL] URL of an installable BISDN Linux image
@@ -18,9 +19,11 @@ usage: $(basename "$0") [OPTIONS] [IMAGEURL]
 "
 
 NEED_CONFIRM=true
+DOWNLOAD=false
 
-while getopts "hy" o; do
+while getopts "dhy" o; do
   case $o in
+    d) DOWNLOAD=true;;
     h) echo "$USAGE";
        exit 0;;
     y) # yes to all answers
@@ -36,8 +39,7 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-if [[ ${NEED_CONFIRM} == false ]]; then shift;
-fi;
+shift $((OPTIND-1))
 
 case $# in
     0)
@@ -58,8 +60,14 @@ if [ "${NEED_CONFIRM}" = true ]; then
   esac
 fi
 
-if [ -f /etc/fw_env.config ]; then
+if [ "${DOWNLOAD}" = true ]; then
+  curl "$INSTALL_FILE" > /onie-installer
+  debugargs=
+else
   debugargs="install_url=${INSTALL_FILE}"
+fi
+
+if [ -f /etc/fw_env.config ]; then
   fw_setenv onie_debugargs "$debugargs"
   fw_setenv onie_boot_reason "install"
 else
@@ -68,7 +76,7 @@ else
   ${MNT_DIR}/onie/tools/bin/onie-boot-mode -q -o install
   grub-reboot ONIE
 
-  sed -i "/export ONIE_EXTRA_CMDLINE_LINUX/ i ONIE_EXTRA_CMDLINE_LINUX=\""\${ONIE_EXTRA_CMDLINE_LINUX}" install_url=${INSTALL_FILE}\" " ${MNT_DIR}/grub/grub.cfg
+  sed -i "/export ONIE_EXTRA_CMDLINE_LINUX/ i ONIE_EXTRA_CMDLINE_LINUX=\""\${ONIE_EXTRA_CMDLINE_LINUX}" $debugargs\" " ${MNT_DIR}/grub/grub.cfg
 fi
 
 systemctl reboot


### PR DESCRIPTION
To allow installation in DHCP-less environments or if the image is available via a protocol not handled by ONIE's wget, allow predownloading the installer to the local filesystem and using localfs discovery of the ONIE install mode.