### PR TITLE
installer: accton-as4610: use explicit default fit configuration

### DIFF
--- a/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
+++ b/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
@@ -118,6 +118,7 @@ create_hw_load_str() {
         ;;
     *)
         echo "Unknown platform \"$platform\", using default configuration" >&2
+        configuration="#conf${separator}arm-accton-as4610.dtb"
         ;;
     esac
 


### PR DESCRIPTION
Currently the installer relies on our default fallback fit configuration is also the default configuration of the fit image. This just happens to be identical, and may change in the future, so be explicit about which configuration is our fallback configuration for AS4610.