### PR TITLE
switch_tcpdump update

### DIFF
--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -58,15 +58,16 @@ def main():
         nargs='+',
         help="tcpdump filter arguments")
 
-    group = parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--filePath",
         type=str,
         help="resulting .pcap file location")
+    # This argument is kept for for backward compatibility. It is not used.
     group.add_argument(
         "--stdout",
         action='store_true',
-        help="output to stdout instead of file - overrides file path",
+        help="output to stdout [default]",
         default=False)
 
     args, extra_args = parser.parse_known_args()
@@ -100,7 +101,6 @@ def main():
         args.filePath,
         args.timeout,
         args.maxSize,
-        args.stdout,
         args.filters,
         extra_args)
 
@@ -154,12 +154,12 @@ def rule_delete(portNumber):
 
 
 def run_tcpdump(portName, filePath, timeoutSeconds,
-                maxSizeMB, stdout, filters, extra_args):
+                maxSizeMB, filters, extra_args):
 
     tcpdumpCommand = ["tcpdump", "-i", portName]
 
     # Override file argument for stdout
-    if not stdout:
+    if filePath:
         tcpdumpCommand = tcpdumpCommand + ["-w", filePath]
         print(f"Saving to {filePath}")
 
@@ -187,7 +187,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                 tcpdumpProcess.terminate()
                 print("Reached capture timeout, stopping")
 
-            if not stdout and os.path.isfile(filePath) \
+            if filePath and os.path.isfile(filePath) \
                     and int(os.path.getsize(filePath) / 1e6) > maxSizeMB:
                 tcpdumpProcess.terminate()
                 print("Max file size reached, stopping")
@@ -198,7 +198,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     # Wait for tcpdump to finish writing before starting to print again.
     tcpdumpProcess.wait()
 
-    if not stdout:
+    if filePath:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
     return tcpdumpProcess.returncode
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -72,10 +72,6 @@ def main():
 
     args, extra_args = parser.parse_known_args()
 
-    print("=" * 80)
-    print("Running switch_tcpdump")
-    print(f"Interface name: {args.inPort}")
-
     if interface_exists(args.inPort) != 0:
         print("Interface %s does not exist" % args.inPort)
         return 1
@@ -94,7 +90,7 @@ def main():
         print("Failed while inserting rule into the ACL table")
         return 1
 
-    print("Rule inserted to the ACL table")
+    print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
     tcpdumpReturnCode = run_tcpdump(
         args.inPort,
@@ -112,9 +108,6 @@ def main():
 
     print("Rule deleted from the ACL table")
 
-    print("Finished capturing")
-    print("=" * 80)
-
     return tcpdumpReturnCode
 
 
@@ -123,7 +116,8 @@ def interface_exists(interfaceName):
         "/sbin/ip",
         "link",
         "show",
-        interfaceName])
+        interfaceName],
+        stdout=subprocess.DEVNULL)
 
     return completed_process.returncode
 
@@ -161,7 +155,6 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     # Override file argument for stdout
     if filePath:
         tcpdumpCommand = tcpdumpCommand + ["-w", filePath]
-        print(f"Saving to {filePath}")
 
     if extra_args:
         tcpdumpCommand = tcpdumpCommand + extra_args
@@ -169,13 +162,11 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     if filters:
         tcpdumpCommand = tcpdumpCommand + filters
 
-    print("Starting tcpdump...")
     if timeoutSeconds:
         print(f"The timeout is {timeoutSeconds} seconds")
-    else:
-        print("Capturing traffic until user interruption")
     starting_time = time.time()
 
+    print("Running", " ".join(tcpdumpCommand))
     tcpdumpProcess = subprocess.Popen(tcpdumpCommand)
 
     try:

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -29,6 +29,7 @@
 
 import argparse
 import os
+import signal
 import subprocess
 import time
 
@@ -102,9 +103,11 @@ def main():
         args.stdout,
         args.filters)
 
+    sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     if rule_delete(portNumber) != 0:
         print("Failed while deleting rule in the ACL table")
         return 1
+    signal.signal(signal.SIGINT, sig)
 
     print("Rule deleted from the ACL table")
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -69,7 +69,7 @@ def main():
         help="output to stdout instead of file - overrides file path",
         default=False)
 
-    args = parser.parse_args()
+    args, extra_args = parser.parse_known_args()
 
     print("=" * 80)
     print("Running switch_tcpdump")
@@ -101,7 +101,8 @@ def main():
         args.timeout,
         args.maxSize,
         args.stdout,
-        args.filters)
+        args.filters,
+        extra_args)
 
     sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     if rule_delete(portNumber) != 0:
@@ -153,7 +154,7 @@ def rule_delete(portNumber):
 
 
 def run_tcpdump(portName, filePath, timeoutSeconds,
-                maxSizeMB, stdout, filters):
+                maxSizeMB, stdout, filters, extra_args):
 
     tcpdumpCommand = ["tcpdump", "-i", portName]
 
@@ -161,6 +162,9 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     if not stdout:
         tcpdumpCommand = tcpdumpCommand + ["-w", filePath]
         print(f"Saving to {filePath}")
+
+    if extra_args:
+        tcpdumpCommand = tcpdumpCommand + extra_args
 
     if filters:
         tcpdumpCommand = tcpdumpCommand + filters

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -191,6 +191,9 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     except KeyboardInterrupt:
         tcpdumpProcess.terminate()
 
+    # Wait for tcpdump to finish writing before starting to print again.
+    tcpdumpProcess.wait()
+
     if not stdout:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
     return tcpdumpProcess.returncode

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -33,11 +33,27 @@ import signal
 import subprocess
 import time
 
+EPILOG = """
+Example usage:
+
+Capture ingress packets on port3 and write at most 100 MB to /tmp/capture.pcap:
+switch_tcpdump --inPort port3 --filePath /tmp/capture.pcap --maxSize 100
+
+For ten seconds, show all packets arriving on port3:
+switch_tcpdump --inPort port3 --timeout 10
+
+Extra arguments are passed to tcpdump directly. For example, to get
+verbose output for ARP packets arriving on port3, use:
+switch_tcpdump --inPort port3 -v 'arp'
+"""
+
 
 def main():
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
-        description="Capture packets in the switch controller")
+        description="Capture ingress packets on switch ports",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog=EPILOG)
     parser.add_argument(
         "--inPort",
         required=True,
@@ -53,10 +69,12 @@ def main():
         type=int,
         help="capture duration, in seconds (0 for manual stop)",
         default=0)
+    # This argument is kept for for backward compatibility. Filter arguments
+    # can just be appended to the command line without adding "--filters".
     parser.add_argument(
         "--filters",
         nargs='+',
-        help="tcpdump filter arguments")
+        help="tcpdump pcap-filter arguments")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(


### PR DESCRIPTION
This PR contains several changes to the switch_tcpdump script which should now be easier to use, more robust, and more powerful while retaining backward compatibility.

Changes:

- avoid leaving ACL table rules after user interruption
- allow passing additional options to tcpdump
- make output to stdout the default (do no require `--stdout` argument)
- add examples to help message
- reduce noise in console messages