### PR TITLE
libnl: ignore incomplete bridge updates

### DIFF
--- a/recipes-support/libnl/libnl/0001-link-bonding-parse-and-expose-bonding-options.patch
+++ b/recipes-support/libnl/libnl/0001-link-bonding-parse-and-expose-bonding-options.patch
@@ -1,7 +1,7 @@
 From f827424185592fa1db39fe822827e12ee894560a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 10:00:37 +0200
-Subject: [PATCH 1/5] link/bonding: parse and expose bonding options
+Subject: [PATCH 1/6] link/bonding: parse and expose bonding options
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -337,5 +337,5 @@ index 7e36de1eb28c..ee5b0e66a65f 100644
 +	rtnl_link_bond_set_xmit_hash_policy;
 +} libnl_3_8;
 -- 
-2.42.0
+2.44.0
 

--- a/recipes-support/libnl/libnl/0002-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0002-WIP-add-info-slave-data-support.patch
@@ -1,7 +1,7 @@
 From 25cba65084cad311a2611df0d78586c032911232 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
-Subject: [PATCH 2/5] WIP: add info slave data support
+Subject: [PATCH 2/6] WIP: add info slave data support
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -265,5 +265,5 @@ index 28d0166295e7..f559de40ace2 100644
  	uint32_t l_promiscuity;
  	uint32_t l_num_tx_queues;
 -- 
-2.42.0
+2.44.0
 

--- a/recipes-support/libnl/libnl/0003-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0003-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,7 +1,7 @@
 From 5d46d6538a88b04738b56a6f2d3bc149f76cd2c5 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
-Subject: [PATCH 3/5] link/bonding: expose state on enslaved interfaces
+Subject: [PATCH 3/6] link/bonding: expose state on enslaved interfaces
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -233,5 +233,5 @@ index ee5b0e66a65f..ec366a7852c1 100644
 +	rtnl_link_bond_slave_set_state;
  } libnl_3_8;
 -- 
-2.42.0
+2.44.0
 

--- a/recipes-support/libnl/libnl/0004-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0004-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,7 +1,7 @@
 From a566cc5f9ecfe13f369840c341976081343b05be Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
-Subject: [PATCH 4/5] bridge-vlan: add per vlan stp state object and cache
+Subject: [PATCH 4/6] bridge-vlan: add per vlan stp state object and cache
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Co-authored-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -718,5 +718,5 @@ index 60a02d2b49d4..c85d2323ac36 100644
  };
  
 -- 
-2.42.0
+2.44.0
 

--- a/recipes-support/libnl/libnl/0005-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0005-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,7 +1,7 @@
 From c116862af228a5deece344f70d3ae06595985d7c Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 1 Mar 2022 12:59:50 +0100
-Subject: [PATCH 5/5] route/route_obj: treat each IPv6 link-local route as
+Subject: [PATCH 5/6] route/route_obj: treat each IPv6 link-local route as
  different
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -50,5 +50,5 @@ index ce68259c30dc..956da472c081 100644
  }
  
 -- 
-2.42.0
+2.44.0
 

--- a/recipes-support/libnl/libnl/0006-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0006-link-ignore-incomplete-bridge-updates.patch
@@ -1,0 +1,72 @@
+From aaed9d875ccdbc0ad9ed8e14c303d04139fca2e6 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 24 Apr 2024 14:13:22 +0200
+Subject: [PATCH 6/6] link: ignore incomplete bridge updates
+
+For currently unknown reasons, the kernel sends a minimal RTM_NEWLINK
+message for a bridge shortly after attaching a port:
+
+-- Debug: Received Message:
+--------------------------   BEGIN NETLINK MESSAGE ---------------------------
+  [NETLINK HEADER] 16 octets
+    .nlmsg_len = 96
+    .type = 16 <route/link::new>
+    .flags = 0 <>
+    .seq = 0
+    .port = 0
+  [PAYLOAD] 16 octets
+    07 00 01 00 40 00 00 00 03 10 00 00 00 00 00 00 ....@...........
+  [ATTR 03] 9 octets
+    73 77 62 72 69 64 67 65 00                      swbridge.
+  [PADDING] 3 octets
+    00 00 00                                        ...
+  [ATTR 10] 4 octets
+    40 00 00 00                                     @...
+  [ATTR 04] 4 octets
+    dc 05 00 00                                     ....
+  [ATTR 16] 1 octets
+    02                                              .
+  [PADDING] 3 octets
+    00 00 00                                        ...
+  [ATTR 01] 6 octets
+    da 56 2f bc 9f 33                               .V/..3
+  [PADDING] 2 octets
+    00 00                                           ..
+  [ATTR 26] 8 octets
+    08 00 02 00 00 00 01 00                         ........
+---------------------------  END NETLINK MESSAGE   ---------------------------
+
+This minimal message does not contain any IFLA_INFO_KIND, but has its
+family set to AF_BRIDGE. This causes the full bridge object in the link
+cache to be replaced with this minimal one, breaking any attempts to get
+information about the bridge interface from the cache.
+
+Work around for now by ignoring these updates.
+
+Upstream-Status: Reported [https://github.com/thom311/libnl/issues/377]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/route/link.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/lib/route/link.c b/lib/route/link.c
+index e33bb3ab61c3..631ca42c1a7c 100644
+--- a/lib/route/link.c
++++ b/lib/route/link.c
+@@ -753,6 +753,13 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
+ 		}
+ 	}
+ 
++	/* ignore incomplete link objects with family set but no kind set */
++	if (   link->ce_msgtype == RTM_NEWLINK
++	    && link->l_family == AF_BRIDGE
++	    && !(link->ce_mask & LINK_ATTR_LINKINFO)
++	    && link->l_index == link->l_master)
++		return 0;
++
+ 	if (   tb[IFLA_PROTINFO]
+ 	    && link->l_af_ops
+ 	    && link->l_af_ops->ao_parse_protinfo) {
+-- 
+2.44.0
+

--- a/recipes-support/libnl/libnl_3.8.0.bb
+++ b/recipes-support/libnl/libnl_3.8.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r1"
+PR = "r2"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -19,6 +19,7 @@ SRC_URI = " \
     file://0003-link-bonding-expose-state-on-enslaved-interfaces.patch \
     file://0004-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
     file://0005-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
+    file://0006-link-ignore-incomplete-bridge-updates.patch \
 "
 
 # commit hash of release tag libnl3_8_0


### PR DESCRIPTION
For currently unknown reasons, the kernel sends a minimal RTM_NEWLINK message for a bridge shortly after attaching a port:

```
-- Debug: Received Message:
--------------------------   BEGIN NETLINK MESSAGE ---------------------------
  [NETLINK HEADER] 16 octets
    .nlmsg_len = 96
    .type = 16 <route/link::new>
    .flags = 0 <>
    .seq = 0
    .port = 0
  [PAYLOAD] 16 octets
    07 00 01 00 40 00 00 00 03 10 00 00 00 00 00 00 ....@...........
  [ATTR 03] 9 octets
    73 77 62 72 69 64 67 65 00                      swbridge.
  [PADDING] 3 octets
    00 00 00                                        ...
  [ATTR 10] 4 octets
    40 00 00 00                                     @...
  [ATTR 04] 4 octets
    dc 05 00 00                                     ....
  [ATTR 16] 1 octets
    02                                              .
  [PADDING] 3 octets
    00 00 00                                        ...
  [ATTR 01] 6 octets
    da 56 2f bc 9f 33                               .V/..3
  [PADDING] 2 octets
    00 00                                           ..
  [ATTR 26] 8 octets
    08 00 02 00 00 00 01 00                         ........
---------------------------  END NETLINK MESSAGE   ---------------------------
```

This minimal message does not contain any `IFLA_INFO_KIND`, but has its family set to `AF_BRIDGE`. This causes the full bridge object in the link cache to be replaced with this minimal one, breaking any attempts to get information about the bridge interface from the cache.

Work around for now by ignoring these updates.