### PR TITLE
installer: accton-as4610: drop fixup for boot_diag command

### DIFF
--- a/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
+++ b/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
@@ -86,13 +86,6 @@ machine_fixups() {
         echo "Fixing up bootcmd from picos to nos"
         fw_setenv -f bootcmd "run check_boot_reason;run nos_bootcmd;run onie_bootcmd"
     fi
-    # test with unquoted variables with spaces will always succeed, so fixup
-    # with escaped quotes, else upgrade will land us in DIAG.
-    boot_diag=$(fw_printenv boot_diag 2>/dev/null || true)
-    if [ "$boot_diag" = 'boot_diag=if test -n $onie_boot_reason; then if test $onie_boot_reason = diag; then run diag_bootcmd; fi; fi' ]; then
-        echo "Fixing up boot_diag command"
-        fw_setenv -f boot_diag 'if test -n \\"$onie_boot_reason\\"; then if test \\"$onie_boot_reason\\" = diag; then run diag_bootcmd; fi; fi'
-    fi
 }
 
 create_hw_load_str() {


### PR DESCRIPTION
Since 15d96e67675a ("onie-tools: user proper interface on u-boot for kernel arguments") we use the proper variable, and onie_boot_reason contains a single word without spaces. So there is no need to fixup the boot_diag command anymore to handle spaces.

Tested via:

1. uninstall current image (which will reset the U-Boot environment)
2. install image with the change applied
3. run `onie-nos-install` to re-install the image