### PR TITLE
Make switch_tcpdump more robust and user-friendly

### DIFF
--- a/recipes-extended/man-pages/files/switch_tcpdump.8
+++ b/recipes-extended/man-pages/files/switch_tcpdump.8
@@ -1,0 +1,116 @@
+.\" switch_tcpdump.8
+.TH "SWITCH_TCPDUMP" "8" "8 May 2024" "" "documentation"
+.SH "NAME"
+switch_tcpdump \- dump switch port traffic
+.SH "SYNOPSIS"
+.B switch_tcpdump
+.B \-\-inPort
+.I INPORT
+.br
+[
+.B \-\-filePath
+.I FILEPATH
+[
+.B \-\-maxSize
+.I \%MAXSIZE_MB
+]
+]
+.br
+[
+.B \-\-timeout
+.I TIMEOUT_SECONDS
+]
+[
+.I TCPDUMP_OPTIONS
+]
+
+.SH "DESCRIPTION"
+\fIswitch_tcpdump\fP is a wrapper around
+.BR tcpdump (8).
+
+Its main features are:
+
+.IP
+Inserting a rule into the ACL table to redirect ingress traffic for
+the given port to the CPU (i.e., the Linux kernel).
+.IP
+Deleting the rule from the ACL table when the capture is stopped.
+.IP
+Preventing file system overflow by stopping the capture when the
+capture file reaches a certain size (default 100 MB).
+.IP
+Stopping the capture after a certain amount of time (default 0, meaning
+no timeout).
+.PP
+
+\fIswitch_tcpdump\fP captures all packets arriving on the given port
+and all packets seen by the kernel going through that port (i.e.,
+any packets that you are sending out from the switch through that
+port). It cannot see any packets that are treated exclusively in the
+switch ASIC; this includes packets that are eventually sent out through
+the capture port without being seen by the kernel (e.g., packets that
+are bridged in hardware).
+
+.SH "OPTIONS"
+.TP
+.BI \-\-inPort " INPORT"
+Listen on specified port (named portX). This is a mandatory option.
+.TP
+.BI \-\-filePath " FILEPATH"
+Write the captured packets to the specified file. If not specified,
+packet descriptions are printed to stdout (mirroring tcpdump behavior).
+The maximum file size is limited by the \fB\%\-\-maxSize\fR option.
+.TP
+.BI \-\-maxSize " MAXSIZE_MB"
+MAXSIZE_MB is the maximum size of the capture file in megabytes. The
+mechanism checks the file size every 0.1 seconds. The default value is
+100. Setting MAXSIZE_MB to 0 disables the size limit.
+.TP
+.BI \-\-timeout " TIMEOUT_SECONDS"
+Stop the capture after TIMEOUT_SECONDS seconds.
+.TP
+.I "TCPDUMP_OPTIONS"
+All remaining arguments are passed on to tcpdump.
+
+.SH "EXAMPLES"
+.LP
+To capture seen packets on port3 and write /tmp/pcap (defaults to 100 MB
+limit):
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 --filePath /tmp/pcap\fP
+.fi
+.RE
+.LP
+To write a capture file with no size limit:
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 --filePath /tmp/pcap --maxSize 0\fP
+.fi
+.RE
+.LP
+To show for ten seconds all packets seen on port3:
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 --timeout 10\fP
+.fi
+.RE
+.LP
+Extra arguments (all arguments after "port3" in this case) are passed on to
+tcpdump:
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 -nv arp or icmp\fP
+.fi
+.RE
+
+.SH "EXIT STATUS"
+\fIswitch_tcpdump\fP returns 2 for all errrors except for \fItcpdump\fP
+errors whose exit status (usually 1 in case of errors) is passed through.
+
+.SH "BUGS"
+Fails to remove the ACL rule if terminated by SIGKILL.
+
+Using \fItcpdump\fP options such as \fB\-i\fR or \fB\-w\fR that
+conflict with \fI\%switch_tcpdump\fP options (e.g., \fB\-\-inPort\fR,
+\fB\-\-filePath\fR) is unsupported and may result in unexpected behavior.

--- a/recipes-extended/man-pages/man-pages_%.bbappend
+++ b/recipes-extended/man-pages/man-pages_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
   file://onie-bisdn-uninstall.1 \
   file://onie-bisdn-upgrade.1 \
   file://onie-bisdn-rescue.1 \
+  file://switch_tcpdump.8 \
 "
 
 do_install:append() {

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -38,15 +38,18 @@ import time
 EPILOG = """
 Example usage:
 
-Capture ingress packets on port3 and write at most 100 MB to /tmp/capture.pcap:
-switch_tcpdump --inPort port3 --filePath /tmp/capture.pcap --maxSize 100
+Capture seen packets on port3 and write /tmp/pcap (defaults to 100 MB limit):
+switch_tcpdump --inPort port3 --filePath /tmp/pcap
 
-For ten seconds, show all packets arriving on port3:
+Write a capture file with no size limit:
+switch_tcpdump --inPort port3 --filePath /tmp/pcap --maxSize 0
+
+For ten seconds, show all packets seen on port3:
 switch_tcpdump --inPort port3 --timeout 10
 
-Extra arguments are passed to tcpdump directly. For example, to get
-verbose output for ARP packets arriving on port3, use:
-switch_tcpdump --inPort port3 -v 'arp'
+Extra arguments (all arguments after "port3" in this case) are passed on to
+tcpdump:
+switch_tcpdump --inPort port3 -nv arp or icmp
 """
 
 
@@ -60,7 +63,7 @@ def main():
 
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
-        description="Capture ingress packets on switch ports",
+        description="Capture packets on switch ports",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=EPILOG)
     parser.add_argument(

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -28,6 +28,8 @@
 """
 
 import argparse
+import builtins
+import functools
 import os
 import signal
 import subprocess
@@ -53,6 +55,9 @@ ERROR_EXIT_CODE = 2
 
 
 def main():
+    # Flush print output immediately
+    builtins.print = functools.partial(print, flush=True)
+
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
         description="Capture ingress packets on switch ports",

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -113,6 +113,8 @@ def main():
 
     portNumber = int(args.inPort.replace("port", ""))
 
+    sig_handler = create_signal_handler(portNumber)
+
     rc = rule_insert(portNumber)
     if rc == -25:
         # A conflicting rule is already present in the ACL table. Remove and
@@ -125,6 +127,9 @@ def main():
 
     print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
     tcpdumpReturnCode = run_tcpdump(
         args.inPort,
         args.filePath,
@@ -133,16 +138,27 @@ def main():
         args.filters,
         extra_args)
 
-    sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     # Remove the rule from the ACL table in case it was not removed by the
     # signal handler. Not having the rule anymore (-30) is not an error.
     if rule_delete(portNumber) not in [0, -30]:
         return ERROR_EXIT_CODE
-    signal.signal(signal.SIGINT, sig)
-
-    print("Rule deleted from the ACL table")
 
     return tcpdumpReturnCode
+
+def create_signal_handler(portNumber):
+    """
+    Create a signal handler that deletes the ACL table rule and raises
+    KeyboardInterrupt to terminate tcpdump.
+    """
+
+    def sig_handler(signum, frame):
+        if rule_delete(portNumber) != 0:
+            # This should never happen.
+            print("Failed while deleting rule in the ACL table")
+        # Raise KeyboardInterrupt to terminate tcpdump.
+        raise KeyboardInterrupt
+
+    return sig_handler
 
 
 def interface_exists(interfaceName):
@@ -182,6 +198,10 @@ def rule_insert(portNumber):
 
 
 def rule_delete(portNumber):
+    # Prevent interruption of rule_delete and re-entrance of the signal handler
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
     completed_process = subprocess.run([
         "/usr/sbin/ofdpa_acl_flow_cli.py",
         "-d",

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -71,7 +71,7 @@ def main():
     parser.add_argument(
         "--maxSize",
         type=int,
-        help="maximum tcpdump file size in MB",
+        help="maximum tcpdump file size in MB (0 for unlimited)",
         default=100)
     parser.add_argument(
         "--timeout",
@@ -205,8 +205,10 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                 tcpdumpProcess.terminate()
                 print("Reached capture timeout, stopping")
 
-            if filePath and os.path.isfile(filePath) \
-                    and int(os.path.getsize(filePath) / 1e6) > maxSizeMB:
+            if (maxSizeMB
+                    and filePath
+                    and os.path.isfile(filePath)
+                    and int(os.path.getsize(filePath) / 1e6) > maxSizeMB):
                 tcpdumpProcess.terminate()
                 print("Max file size reached, stopping")
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -157,9 +157,21 @@ def rule_insert(portNumber):
         str(portNumber),
         "--inPortMask",
         "0xffffffff",
-        "--controller"])
+        "--controller"],
+        text=True,
+        capture_output=True)
 
-    return completed_process.returncode
+    rc = int.from_bytes(
+        completed_process.returncode.to_bytes(1, "little", signed=False),
+        "little",
+        signed=True,
+    )
+
+    if rc not in [0, -25]:
+        print(completed_process.stdout)
+        print("Unexpected return code while inserting rule into the ACL table")
+
+    return rc
 
 
 def rule_delete(portNumber):
@@ -169,9 +181,21 @@ def rule_delete(portNumber):
         "--inPort",
         str(portNumber),
         "--inPortMask",
-        "0xffffffff"])
+        "0xffffffff"],
+        text=True,
+        capture_output=True)
 
-    return completed_process.returncode
+    rc = int.from_bytes(
+        completed_process.returncode.to_bytes(1, "little", signed=False),
+        "little",
+        signed=True,
+    )
+
+    if rc not in [0, -30]:
+        print(completed_process.stdout)
+        print("Unexpected return code while deleting rule from the ACL table")
+
+    return rc
 
 
 def run_tcpdump(portName, filePath, timeoutSeconds,

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -48,6 +48,10 @@ switch_tcpdump --inPort port3 -v 'arp'
 """
 
 
+# tcpdump returns 1 on error. Use 2 for this wrapper to indicate the source.
+ERROR_EXIT_CODE = 2
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
@@ -92,21 +96,21 @@ def main():
 
     if interface_exists(args.inPort) != 0:
         print("Interface %s does not exist" % args.inPort)
-        return 1
+        return ERROR_EXIT_CODE
 
     if args.maxSize <= 0:
         print("--maxSize should be greater than 0 (got %d)" % args.maxSize)
-        return 1
+        return ERROR_EXIT_CODE
 
     if args.timeout < 0:
         print("--timeout should 0 or greater (got %d)" % args.timeout)
-        return 1
+        return ERROR_EXIT_CODE
 
     portNumber = int(args.inPort.replace("port", ""))
 
     if rule_insert(portNumber) != 0:
         print("Failed while inserting rule into the ACL table")
-        return 1
+        return ERROR_EXIT_CODE
 
     print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
@@ -121,7 +125,7 @@ def main():
     sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     if rule_delete(portNumber) != 0:
         print("Failed while deleting rule in the ACL table")
-        return 1
+        return ERROR_EXIT_CODE
     signal.signal(signal.SIGINT, sig)
 
     print("Rule deleted from the ACL table")

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -113,9 +113,15 @@ def main():
 
     portNumber = int(args.inPort.replace("port", ""))
 
-    if rule_insert(portNumber) != 0:
-        print("Failed while inserting rule into the ACL table")
-        return ERROR_EXIT_CODE
+    rc = rule_insert(portNumber)
+    if rc == -25:
+        # A conflicting rule is already present in the ACL table. Remove and
+        # try again.
+        if rule_delete(portNumber) != 0:
+            return ERROR_EXIT_CODE
+        if rule_insert(portNumber) != 0:
+            print("Failed while inserting rule into the ACL table")
+            return ERROR_EXIT_CODE
 
     print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
@@ -128,8 +134,9 @@ def main():
         extra_args)
 
     sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
-    if rule_delete(portNumber) != 0:
-        print("Failed while deleting rule in the ACL table")
+    # Remove the rule from the ACL table in case it was not removed by the
+    # signal handler. Not having the rule anymore (-30) is not an error.
+    if rule_delete(portNumber) not in [0, -30]:
         return ERROR_EXIT_CODE
     signal.signal(signal.SIGINT, sig)
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -50,6 +50,8 @@ switch_tcpdump --inPort port3 --timeout 10
 Extra arguments (all arguments after "port3" in this case) are passed on to
 tcpdump:
 switch_tcpdump --inPort port3 -nv arp or icmp
+
+For additional information, see the man page for switch_tcpdump(8).
 """
 
 


### PR DESCRIPTION
This PR contains a number of changes for switch_tcpdump that should make the script more robust and more user-friendly.

In particular, a custom signal handler increases the chance that we manage to remove the ACL rule correctly even when getting SIGINT or SIGTERM in quick succession. The script can now also deal automatically with an existing ACL rule (e.g., left by a previous switch_tcpdump terminated by SIGKILL) instead of passing on the error message from ofda_acl_flow_cli.py.

The documentation has also been updated and extended.