### PR TITLE
libnl: ignore flags and weight of nexthops when doing a strict route …

### DIFF
--- a/recipes-support/libnl/libnl/0001-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch
+++ b/recipes-support/libnl/libnl/0001-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch
@@ -1,0 +1,63 @@
+From 5b6ce5b66be2b44f4e915b494ef9e1a4beec3e2d Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Tue, 30 Apr 2024 14:05:33 +0200
+Subject: [PATCH 1/9] route: fix IPv6 ecmp route deleted nexthop matching
+
+When the kernel sends a ECMP route update with just the deleted nexthop,
+the nexthop will have no associated weight, and its flags may indicate
+that it is dead:
+
+    route_update: RTM_DELROUTE
+    new route:
+    inet6 default table main type unicast <DEAD,>
+        scope global priority 0x400 protocol 0x9
+        nexthop via fe80::b226:28ff:fe62:8841 dev port4 <dead,>
+    old route:
+    inet6 default table main type unicast
+        scope global priority 0x400 protocol 0x9
+        nexthop via fe80::b226:28ff:fe62:8841 dev port4 weight 0 <>
+        nexthop via fe80::fa8e:a1ff:fee0:8344 dev port49 weight 0 <>
+        nexthop via fe80::b226:28ff:fe62:d400 dev port3 weight 0 <>
+        nexthop via fe80::fa8e:a1ff:fee0:8349 dev port54 weight 0 <>
+
+Since we are comparing the nexthops strictly with all attributes, we can
+never match the deleted nexthop. This causes libnl to fail to remove the
+deleted nexthop from the route, and consequently send out a nop-update
+and a desync of the route in the cache and in the kernel.
+
+Fix this by ignoring NH_ATTR_FLAGS (0x1) and NH_ATTR_WEIGHT (0x2) when
+comparing nexthops to properly match the deleted one.
+
+Upstream-Status: Backport [https://github.com/thom311/libnl/commit/2301992be667fa51084b40ac6ad4a4155a09aeb1]
+Fixes: 29b71371e764 ("route cache: Fix handling of ipv6 multipath routes")
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+
+https://github.com/thom311/libnl/pull/382
+---
+ lib/route/route_obj.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/lib/route/route_obj.c b/lib/route/route_obj.c
+index ce68259c30dc..cf538db93680 100644
+--- a/lib/route/route_obj.c
++++ b/lib/route/route_obj.c
+@@ -578,7 +578,15 @@ static int route_update(struct nl_object *old_obj, struct nl_object *new_obj)
+ 		 */
+ 		nl_list_for_each_entry(old_nh, &old_route->rt_nexthops,
+ 			rtnh_list) {
+-			if (!rtnl_route_nh_compare(old_nh, new_nh, ~0, 0)) {
++			/*
++			 * Since the new route has only one nexthop, it's not
++			 * an ECMP route and the nexthop won't have a weight.
++			 * Similarily, the nexthop might have been marked as
++			 * DEAD in its flags if it was deleted.
++			 * Therefore ignore NH_ATTR_FLAGS (= 0x1) and
++			 * NH_ATTR_WEIGHT (= 0x2) while comparing nexthops.
++			 */
++			if (!rtnl_route_nh_compare(old_nh, new_nh, ~0x3, 0)) {
+ 
+ 				rtnl_route_remove_nexthop(old_route, old_nh);
+ 
+-- 
+2.44.0
+

--- a/recipes-support/libnl/libnl/0002-nexthop-add-a-identical-helper-function.patch
+++ b/recipes-support/libnl/libnl/0002-nexthop-add-a-identical-helper-function.patch
@@ -1,0 +1,83 @@
+From 45e07d1775723b6d738c921ec990ed4d6f971ac3 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 13 May 2024 14:00:39 +0200
+Subject: [PATCH 2/9] nexthop: add a identical helper function
+
+Not all attributes of a nexthop are id attributes, e.g. the flags will
+contain state (LINKDOWN, DEAD) of the attached link about which the
+kernel will not send route updates.
+
+Likewise, the weight may not exist when processing an ECMP IPv6 route
+update which only contains a single nexthop.
+
+Since rtnl_nexthop isn't a first class cache object, we cannot use
+nl_object_identical(), so add a separate identical helper function which
+compares only fixed attributes.
+
+Upstream-Status: Submitted [https://github.com/thom311/libnl/pull/384]
+[jonas.gorski: adapted for libnl 3.8]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ include/netlink/route/nexthop.h |  3 +++
+ lib/route/nexthop.c             | 17 +++++++++++++++++
+ libnl-route-3.sym               |  5 +++++
+ 3 files changed, 25 insertions(+)
+
+diff --git a/include/netlink/route/nexthop.h b/include/netlink/route/nexthop.h
+index c4a2604aa8f8..1beb9fa9e679 100644
+--- a/include/netlink/route/nexthop.h
++++ b/include/netlink/route/nexthop.h
+@@ -30,6 +30,9 @@ extern int		rtnl_route_nh_compare(struct rtnl_nexthop *,
+ 					      struct rtnl_nexthop *,
+ 					      uint32_t, int);
+ 
++extern int		rtnl_route_nh_identical(struct rtnl_nexthop *,
++						struct rtnl_nexthop *);
++
+ extern void		rtnl_route_nh_dump(struct rtnl_nexthop *,
+ 					   struct nl_dump_params *);
+ 
+diff --git a/lib/route/nexthop.c b/lib/route/nexthop.c
+index 962f2bab59c8..7e0df6136b04 100644
+--- a/lib/route/nexthop.c
++++ b/lib/route/nexthop.c
+@@ -136,6 +136,23 @@ int rtnl_route_nh_compare(struct rtnl_nexthop *a, struct rtnl_nexthop *b,
+ 	return diff;
+ }
+ 
++/**
++ * Check if the fixed attributes of two nexthops are identical, and may
++ * only differ in flags or weight.
++ *
++ * @arg a		a nexthop
++ * @arg b		another nexthop
++ *
++ * @return true if both nexthop have equal attributes, otherwise false.
++ */
++int rtnl_route_nh_identical(struct rtnl_nexthop *a, struct rtnl_nexthop *b)
++{
++	return !rtnl_route_nh_compare(a, b,
++				      NH_ATTR_IFINDEX | NH_ATTR_REALMS |
++				      NH_ATTR_GATEWAY | NH_ATTR_NEWDST |
++				      NH_ATTR_VIA | NH_ATTR_ENCAP, 0);
++}
++
+ static void nh_dump_line(struct rtnl_nexthop *nh, struct nl_dump_params *dp)
+ {
+ 	struct nl_cache *link_cache;
+diff --git a/libnl-route-3.sym b/libnl-route-3.sym
+index 7e36de1eb28c..e36175b500a6 100644
+--- a/libnl-route-3.sym
++++ b/libnl-route-3.sym
+@@ -1306,3 +1306,8 @@ global:
+ 	rtnl_nh_set_fdb;
+ 	rtnl_nh_set_gateway;
+ } libnl_3_7;
++
++libnl_3_9 {
++global:
++	rtnl_route_nh_identical;
++} libnl_3_8;
+-- 
+2.44.0
+

--- a/recipes-support/libnl/libnl/0003-route-use-the-new-helper-function-for-comparing-next.patch
+++ b/recipes-support/libnl/libnl/0003-route-use-the-new-helper-function-for-comparing-next.patch
@@ -1,0 +1,74 @@
+From cbb143fb12980b92f39f736ee54e2f358f8feb14 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 13 May 2024 14:06:48 +0200
+Subject: [PATCH 3/9] route: use the new helper function for comparing nexthops
+
+When a route is created while the interface has no link, we get a
+notification with the route and the nexthop having the flag LINKDOWN.
+
+If the interface later gets a link, we do not get a route notification
+about it, so the route and nexthop stay at LINKDOWN in the libnl cache.
+
+If the route then gets removed again, the to be removed route will not
+have the LINKDOWN flag anymore, which then can break comparison of the
+nexthop(s).
+
+So use the new nexthop identical helper to avoid this scenario.
+
+Upstream-Status: Submitted [https://github.com/thom311/libnl/pull/384]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/route/route_obj.c | 16 ++++------------
+ 1 file changed, 4 insertions(+), 12 deletions(-)
+
+diff --git a/lib/route/route_obj.c b/lib/route/route_obj.c
+index cf538db93680..6d36f80d2e13 100644
+--- a/lib/route/route_obj.c
++++ b/lib/route/route_obj.c
+@@ -451,7 +451,7 @@ static uint64_t route_compare(struct nl_object *_a, struct nl_object *_b,
+ 			found = 0;
+ 			nl_list_for_each_entry(nh_b, &b->rt_nexthops,
+ 					       rtnh_list) {
+-				if (!rtnl_route_nh_compare(nh_a, nh_b, ~0, 0)) {
++				if (rtnl_route_nh_identical(nh_a, nh_b)) {
+ 					found = 1;
+ 					break;
+ 				}
+@@ -466,7 +466,7 @@ static uint64_t route_compare(struct nl_object *_a, struct nl_object *_b,
+ 			found = 0;
+ 			nl_list_for_each_entry(nh_a, &a->rt_nexthops,
+ 					       rtnh_list) {
+-				if (!rtnl_route_nh_compare(nh_a, nh_b, ~0, 0)) {
++				if (rtnl_route_nh_identical(nh_a, nh_b)) {
+ 					found = 1;
+ 					break;
+ 				}
+@@ -542,7 +542,7 @@ static int route_update(struct nl_object *old_obj, struct nl_object *new_obj)
+ 		 * Do not add the nexthop to old route if it was already added before
+ 		 */
+ 		nl_list_for_each_entry(old_nh, &old_route->rt_nexthops, rtnh_list) {
+-			if (!rtnl_route_nh_compare(old_nh, new_nh, ~0, 0)) {
++			if (rtnl_route_nh_identical(old_nh, new_nh)) {
+ 				return 0;
+ 			}
+ 		}
+@@ -578,15 +578,7 @@ static int route_update(struct nl_object *old_obj, struct nl_object *new_obj)
+ 		 */
+ 		nl_list_for_each_entry(old_nh, &old_route->rt_nexthops,
+ 			rtnh_list) {
+-			/*
+-			 * Since the new route has only one nexthop, it's not
+-			 * an ECMP route and the nexthop won't have a weight.
+-			 * Similarily, the nexthop might have been marked as
+-			 * DEAD in its flags if it was deleted.
+-			 * Therefore ignore NH_ATTR_FLAGS (= 0x1) and
+-			 * NH_ATTR_WEIGHT (= 0x2) while comparing nexthops.
+-			 */
+-			if (!rtnl_route_nh_compare(old_nh, new_nh, ~0x3, 0)) {
++			if (rtnl_route_nh_identical(old_nh, new_nh)) {
+ 
+ 				rtnl_route_remove_nexthop(old_route, old_nh);
+ 
+-- 
+2.44.0
+

--- a/recipes-support/libnl/libnl/0004-link-bonding-parse-and-expose-bonding-options.patch
+++ b/recipes-support/libnl/libnl/0004-link-bonding-parse-and-expose-bonding-options.patch
@@ -1,14 +1,14 @@
-From f827424185592fa1db39fe822827e12ee894560a Mon Sep 17 00:00:00 2001
+From 7507b575413a515f09de79cae7a71c549437b121 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 10:00:37 +0200
-Subject: [PATCH 1/6] link/bonding: parse and expose bonding options
+Subject: [PATCH 4/9] link/bonding: parse and expose bonding options
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  include/netlink/route/link/bonding.h |   9 +
  lib/route/link/bonding.c             | 235 ++++++++++++++++++++++++++-
- libnl-route-3.sym                    |  10 ++
- 3 files changed, 247 insertions(+), 7 deletions(-)
+ libnl-route-3.sym                    |   6 +
+ 3 files changed, 243 insertions(+), 7 deletions(-)
 
 diff --git a/include/netlink/route/link/bonding.h b/include/netlink/route/link/bonding.h
 index e85b44a24b59..b64964c70b62 100644
@@ -319,23 +319,21 @@ index 640a62caca78..4ad1ee6f547d 100644
  
  /**
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index 7e36de1eb28c..ee5b0e66a65f 100644
+index e36175b500a6..dee4c64094bb 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1306,3 +1306,13 @@ global:
- 	rtnl_nh_set_fdb;
- 	rtnl_nh_set_gateway;
- } libnl_3_7;
-+
-+libnl_3_9 {
-+global:
+@@ -1309,5 +1309,11 @@ global:
+ 
+ libnl_3_9 {
+ global:
 +	rtnl_link_bond_get_activeslave;
 +	rtnl_link_bond_get_mode;
 +	rtnl_link_bond_get_primary;
 +	rtnl_link_bond_get_xmit_hash_policy;
 +	rtnl_link_bond_set_primary;
 +	rtnl_link_bond_set_xmit_hash_policy;
-+} libnl_3_8;
+ 	rtnl_route_nh_identical;
+ } libnl_3_8;
 -- 
 2.44.0
 

--- a/recipes-support/libnl/libnl/0005-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0005-WIP-add-info-slave-data-support.patch
@@ -1,7 +1,7 @@
-From 25cba65084cad311a2611df0d78586c032911232 Mon Sep 17 00:00:00 2001
+From af6039212ac7c311388ce66104528a37417f2d8e Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
-Subject: [PATCH 2/6] WIP: add info slave data support
+Subject: [PATCH 5/9] WIP: add info slave data support
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---

--- a/recipes-support/libnl/libnl/0006-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0006-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,7 +1,7 @@
-From 5d46d6538a88b04738b56a6f2d3bc149f76cd2c5 Mon Sep 17 00:00:00 2001
+From ac3dad258f10cbe0df0bfa0ec754446d416b51b8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
-Subject: [PATCH 3/6] link/bonding: expose state on enslaved interfaces
+Subject: [PATCH 6/9] link/bonding: expose state on enslaved interfaces
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -222,15 +222,16 @@ index 4ad1ee6f547d..a47871ee3e6a 100644
   * Allocate link object of type bond
   *
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index ee5b0e66a65f..ec366a7852c1 100644
+index dee4c64094bb..f7017e161e43 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1315,4 +1315,6 @@ global:
+@@ -1315,5 +1315,7 @@ global:
  	rtnl_link_bond_get_xmit_hash_policy;
  	rtnl_link_bond_set_primary;
  	rtnl_link_bond_set_xmit_hash_policy;
 +	rtnl_link_bond_slave_get_state;
 +	rtnl_link_bond_slave_set_state;
+ 	rtnl_route_nh_identical;
  } libnl_3_8;
 -- 
 2.44.0

--- a/recipes-support/libnl/libnl/0007-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0007-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,7 +1,7 @@
-From a566cc5f9ecfe13f369840c341976081343b05be Mon Sep 17 00:00:00 2001
+From 1b1bc4b35a8a1a3e863395e416ff009cc52dc6c2 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
-Subject: [PATCH 4/6] bridge-vlan: add per vlan stp state object and cache
+Subject: [PATCH 7/9] bridge-vlan: add per vlan stp state object and cache
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Co-authored-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -589,7 +589,7 @@ index 75f03cd154af..bc10208c8459 100644
 +	nl_cli_bridge_vlan_parse_ifindex;
 +} libnl_3_8;
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index ec366a7852c1..141fd07d9538 100644
+index f7017e161e43..dac68eb65ef5 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
 @@ -1310,6 +1310,19 @@ global:

--- a/recipes-support/libnl/libnl/0008-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0008-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,7 +1,7 @@
-From c116862af228a5deece344f70d3ae06595985d7c Mon Sep 17 00:00:00 2001
+From b6dd92c5aa86a1f26200fda6eb64d902fb2a03a0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 1 Mar 2022 12:59:50 +0100
-Subject: [PATCH 5/6] route/route_obj: treat each IPv6 link-local route as
+Subject: [PATCH 8/9] route/route_obj: treat each IPv6 link-local route as
  different
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -10,7 +10,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 29 insertions(+)
 
 diff --git a/lib/route/route_obj.c b/lib/route/route_obj.c
-index ce68259c30dc..956da472c081 100644
+index 6d36f80d2e13..93f3d87b9c96 100644
 --- a/lib/route/route_obj.c
 +++ b/lib/route/route_obj.c
 @@ -389,6 +389,35 @@ static uint32_t route_id_attrs_get(struct nl_object *obj)

--- a/recipes-support/libnl/libnl/0009-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0009-link-ignore-incomplete-bridge-updates.patch
@@ -1,7 +1,7 @@
-From aaed9d875ccdbc0ad9ed8e14c303d04139fca2e6 Mon Sep 17 00:00:00 2001
+From 7c3976ccf11bd499d84c54a0693239c273cd371a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 24 Apr 2024 14:13:22 +0200
-Subject: [PATCH 6/6] link: ignore incomplete bridge updates
+Subject: [PATCH 9/9] link: ignore incomplete bridge updates
 
 For currently unknown reasons, the kernel sends a minimal RTM_NEWLINK
 message for a bridge shortly after attaching a port:

--- a/recipes-support/libnl/libnl_3.8.0.bb
+++ b/recipes-support/libnl/libnl_3.8.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r2"
+PR = "r3"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -14,12 +14,15 @@ DEPENDS = "flex-native bison-native"
 
 SRC_URI = " \
     git://github.com/thom311/${BPN}.git;protocol=https;branch=main \
-    file://0001-link-bonding-parse-and-expose-bonding-options.patch \
-    file://0002-WIP-add-info-slave-data-support.patch \
-    file://0003-link-bonding-expose-state-on-enslaved-interfaces.patch \
-    file://0004-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
-    file://0005-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
-    file://0006-link-ignore-incomplete-bridge-updates.patch \
+    file://0001-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch \
+    file://0002-nexthop-add-a-identical-helper-function.patch \
+    file://0003-route-use-the-new-helper-function-for-comparing-next.patch \
+    file://0004-link-bonding-parse-and-expose-bonding-options.patch \
+    file://0005-WIP-add-info-slave-data-support.patch \
+    file://0006-link-bonding-expose-state-on-enslaved-interfaces.patch \
+    file://0007-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
+    file://0008-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
+    file://0009-link-ignore-incomplete-bridge-updates.patch \
 "
 
 # commit hash of release tag libnl3_8_0


### PR DESCRIPTION
…comparison

When a route is created while the interface has no link, we get a notification with the route and the nexthop having the flag LINKDOWN.

If the interface later gets a link, we do not get a route notification about it, so the route and nexthop stay at LINKDOWN in the libnl cache.

If the route then gets removed again, the to be removed route will not have the LINKDOWN flag anymore, which then can break comparison of the nexthop(s).

So add a new helper for ignoring FLAGS and WEIGHT for nexthops, and use it everywhere we want to tell if it's the same nexthop, but not necessarily in the same state.

This fixes spurious missed route updates when the old object wasn't found.