### PR TITLE
installer: add support for default configurations

### DIFF
--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -359,8 +359,10 @@ old_part=$(eval $detect_bisdn_linux_partition $boot_dev)
 if [ -n "$old_part" ]; then
     # old_part contains partition number of existing BISDN Linux installation
 
-    # backup existing config
-    backup_cfg $boot_dev $old_part
+    if [ -z "$BISDN_DEFAULT_CONFIG" ]; then
+        # backup existing config
+        backup_cfg $boot_dev $old_part
+    fi
     # delete existing partition
     eval $delete_bisdn_linux_partition $boot_dev $old_part
 fi
@@ -465,6 +467,17 @@ platform_setup
 if [ "${DO_RESTORE}" = true ]; then
     restore_cfg $backup_tmp_dir $bisdn_linux_mnt
 fi;
+
+if [ -n "$BISDN_DEFAULT_CONFIG" ] && [ "$BISDN_DEFAULT_CONFIG" != "none" ]; then
+    example_path="/usr/share/docs/baseboxd/examples/$BISDN_DEFAULT_CONFIG"
+    if [ -d "${bisdn_linux_mnt}${example_path}" ]; then
+        # copy *.netdev and *.network files, but not e.g. *.md
+        cp "${bisdn_linux_mnt}${example_path}/"*.net* \
+            "${bisdn_linux_mnt}/${SYSTEMD_NETWORK_CONFDIR}"
+    else
+        echo "WARNING: no default config '$BISDN_DEFAULT_CONFIG' found."
+    fi
+fi
 
 # clean up
 umount $bisdn_linux_mnt || {


### PR DESCRIPTION
Add support for creating a default network config during installation.

By setting the environment variable BISDN_DEFAULT_CONFIG, the identically named example configuration shipped by the baseboxd package will be installed.

This will disable the take over of any configuration from a previous installation, to avoid configuration conflicts.

As a special keyword, 'none' is accepted as a way to prevent configuration backup without creating a default configuration.