### PR TITLE
libnl: backport fix for updated object notifications

### DIFF
--- a/recipes-support/libnl/libnl/0001-cache-fix-new-object-in-callback-v2-on-updated-objec.patch
+++ b/recipes-support/libnl/libnl/0001-cache-fix-new-object-in-callback-v2-on-updated-objec.patch
@@ -1,0 +1,40 @@
+From b6f7c5fbd6b0f5649d54804acb56c4b95db0fae9 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Apr 2024 16:32:21 +0200
+Subject: [PATCH 01/10] cache: fix new object in callback v2 on updated objects
+
+When calling the callback v2 for objects that were updated, we pass the
+update ("obj") instead of the updated object ("old") as new.
+
+Presumably this wasn't intended, so pass the updated object as new.
+
+This avoids weird updates where the new object is significantly smaller
+than the old one. E.g. for IPv6 multipath route updates, old would be
+the full route with all nexthops, while new would be a partial route
+with only the added/removed nexthop.
+
+Upstream-Status: backport [https://github.com/thom311/libnl/commit/3a43faa1aa8e9fb98ae8bc41496ceabc4c0838f1]
+Fixes: 66d032ad443a ("cache_mngr: add include callback v2")
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+
+https://github.com/thom311/libnl/pull/381
+---
+ lib/cache.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/cache.c b/lib/cache.c
+index dd059c11e1a8..bae641ded565 100644
+--- a/lib/cache.c
++++ b/lib/cache.c
+@@ -808,7 +808,7 @@ static int cache_include(struct nl_cache *cache, struct nl_object *obj,
+ 			 */
+ 			if (nl_object_update(old, obj) == 0) {
+ 				if (cb_v2) {
+-					cb_v2(cache, clone, obj, diff,
++					cb_v2(cache, clone, old, diff,
+ 					      NL_ACT_CHANGE, data);
+ 					nl_object_put(clone);
+ 				} else if (cb)
+-- 
+2.45.0
+

--- a/recipes-support/libnl/libnl/0002-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch
+++ b/recipes-support/libnl/libnl/0002-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch
@@ -1,7 +1,7 @@
-From 5b6ce5b66be2b44f4e915b494ef9e1a4beec3e2d Mon Sep 17 00:00:00 2001
+From aa91e496249d0942c4287f7ac576dfc9b209d26f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 30 Apr 2024 14:05:33 +0200
-Subject: [PATCH 1/9] route: fix IPv6 ecmp route deleted nexthop matching
+Subject: [PATCH 02/10] route: fix IPv6 ecmp route deleted nexthop matching
 
 When the kernel sends a ECMP route update with just the deleted nexthop,
 the nexthop will have no associated weight, and its flags may indicate
@@ -59,5 +59,5 @@ index ce68259c30dc..cf538db93680 100644
  				rtnl_route_remove_nexthop(old_route, old_nh);
  
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0003-nexthop-add-a-identical-helper-function.patch
+++ b/recipes-support/libnl/libnl/0003-nexthop-add-a-identical-helper-function.patch
@@ -1,7 +1,7 @@
-From 45e07d1775723b6d738c921ec990ed4d6f971ac3 Mon Sep 17 00:00:00 2001
+From 87d4026cb13a1d05b222c0aadee4cf85422f49dd Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 May 2024 14:00:39 +0200
-Subject: [PATCH 2/9] nexthop: add a identical helper function
+Subject: [PATCH 03/10] nexthop: add a identical helper function
 
 Not all attributes of a nexthop are id attributes, e.g. the flags will
 contain state (LINKDOWN, DEAD) of the attached link about which the
@@ -14,7 +14,7 @@ Since rtnl_nexthop isn't a first class cache object, we cannot use
 nl_object_identical(), so add a separate identical helper function which
 compares only fixed attributes.
 
-Upstream-Status: Submitted [https://github.com/thom311/libnl/pull/384]
+Upstream-Status: Backport [https://github.com/thom311/libnl/commit/8cf29d7b4a8f4dadcc68932edc23e05f5d0fee89]
 [jonas.gorski: adapted for libnl 3.8]
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -79,5 +79,5 @@ index 7e36de1eb28c..e36175b500a6 100644
 +	rtnl_route_nh_identical;
 +} libnl_3_8;
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0004-route-use-the-new-helper-function-for-comparing-next.patch
+++ b/recipes-support/libnl/libnl/0004-route-use-the-new-helper-function-for-comparing-next.patch
@@ -1,7 +1,8 @@
-From cbb143fb12980b92f39f736ee54e2f358f8feb14 Mon Sep 17 00:00:00 2001
+From 490b8a8a27d62bd37f31d08cbfc4d4caa3f2ca51 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 May 2024 14:06:48 +0200
-Subject: [PATCH 3/9] route: use the new helper function for comparing nexthops
+Subject: [PATCH 04/10] route: use the new helper function for comparing
+ nexthops
 
 When a route is created while the interface has no link, we get a
 notification with the route and the nexthop having the flag LINKDOWN.
@@ -15,7 +16,7 @@ nexthop(s).
 
 So use the new nexthop identical helper to avoid this scenario.
 
-Upstream-Status: Submitted [https://github.com/thom311/libnl/pull/384]
+Upstream-Status: Backport [https://github.com/thom311/libnl/commit/861fb8090c4bd670890b310b9761edfd1d12d916]
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  lib/route/route_obj.c | 16 ++++------------
@@ -70,5 +71,5 @@ index cf538db93680..6d36f80d2e13 100644
  				rtnl_route_remove_nexthop(old_route, old_nh);
  
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0005-link-bonding-parse-and-expose-bonding-options.patch
+++ b/recipes-support/libnl/libnl/0005-link-bonding-parse-and-expose-bonding-options.patch
@@ -1,7 +1,7 @@
-From 7507b575413a515f09de79cae7a71c549437b121 Mon Sep 17 00:00:00 2001
+From 6927bcefbfc3e853bd7073ac997eb581e1bb2189 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 10:00:37 +0200
-Subject: [PATCH 4/9] link/bonding: parse and expose bonding options
+Subject: [PATCH 05/10] link/bonding: parse and expose bonding options
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -335,5 +335,5 @@ index e36175b500a6..dee4c64094bb 100644
  	rtnl_route_nh_identical;
  } libnl_3_8;
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0006-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0006-WIP-add-info-slave-data-support.patch
@@ -1,7 +1,7 @@
-From af6039212ac7c311388ce66104528a37417f2d8e Mon Sep 17 00:00:00 2001
+From e0825cfdebf8418ef4b27ebc140cdec35df9ebc1 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
-Subject: [PATCH 5/9] WIP: add info slave data support
+Subject: [PATCH 06/10] WIP: add info slave data support
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -265,5 +265,5 @@ index 28d0166295e7..f559de40ace2 100644
  	uint32_t l_promiscuity;
  	uint32_t l_num_tx_queues;
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0007-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0007-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,7 +1,7 @@
-From ac3dad258f10cbe0df0bfa0ec754446d416b51b8 Mon Sep 17 00:00:00 2001
+From a1e7c1c15982083bbcb68bcfb01e239ebbbd270b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
-Subject: [PATCH 6/9] link/bonding: expose state on enslaved interfaces
+Subject: [PATCH 07/10] link/bonding: expose state on enslaved interfaces
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -234,5 +234,5 @@ index dee4c64094bb..f7017e161e43 100644
  	rtnl_route_nh_identical;
  } libnl_3_8;
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0008-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0008-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,7 +1,7 @@
-From 1b1bc4b35a8a1a3e863395e416ff009cc52dc6c2 Mon Sep 17 00:00:00 2001
+From 6099d435b4c1784cf416c1b76704b364c5fa7e01 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
-Subject: [PATCH 7/9] bridge-vlan: add per vlan stp state object and cache
+Subject: [PATCH 08/10] bridge-vlan: add per vlan stp state object and cache
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Co-authored-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -718,5 +718,5 @@ index 60a02d2b49d4..c85d2323ac36 100644
  };
  
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0009-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0009-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,7 +1,7 @@
-From b6dd92c5aa86a1f26200fda6eb64d902fb2a03a0 Mon Sep 17 00:00:00 2001
+From c5235774783a9307fc044488f8576bd5bd87d113 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 1 Mar 2022 12:59:50 +0100
-Subject: [PATCH 8/9] route/route_obj: treat each IPv6 link-local route as
+Subject: [PATCH 09/10] route/route_obj: treat each IPv6 link-local route as
  different
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -50,5 +50,5 @@ index 6d36f80d2e13..93f3d87b9c96 100644
  }
  
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl/0010-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0010-link-ignore-incomplete-bridge-updates.patch
@@ -1,7 +1,7 @@
-From 7c3976ccf11bd499d84c54a0693239c273cd371a Mon Sep 17 00:00:00 2001
+From 6f57f9f19b672897214eefe86c01ec2aa109d53d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 24 Apr 2024 14:13:22 +0200
-Subject: [PATCH 9/9] link: ignore incomplete bridge updates
+Subject: [PATCH 10/10] link: ignore incomplete bridge updates
 
 For currently unknown reasons, the kernel sends a minimal RTM_NEWLINK
 message for a bridge shortly after attaching a port:
@@ -68,5 +68,5 @@ index e33bb3ab61c3..631ca42c1a7c 100644
  	    && link->l_af_ops
  	    && link->l_af_ops->ao_parse_protinfo) {
 -- 
-2.44.0
+2.45.0
 

--- a/recipes-support/libnl/libnl_3.8.0.bb
+++ b/recipes-support/libnl/libnl_3.8.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r3"
+PR = "r4"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -14,15 +14,16 @@ DEPENDS = "flex-native bison-native"
 
 SRC_URI = " \
     git://github.com/thom311/${BPN}.git;protocol=https;branch=main \
-    file://0001-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch \
-    file://0002-nexthop-add-a-identical-helper-function.patch \
-    file://0003-route-use-the-new-helper-function-for-comparing-next.patch \
-    file://0004-link-bonding-parse-and-expose-bonding-options.patch \
-    file://0005-WIP-add-info-slave-data-support.patch \
-    file://0006-link-bonding-expose-state-on-enslaved-interfaces.patch \
-    file://0007-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
-    file://0008-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
-    file://0009-link-ignore-incomplete-bridge-updates.patch \
+    file://0001-cache-fix-new-object-in-callback-v2-on-updated-objec.patch \
+    file://0002-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch \
+    file://0003-nexthop-add-a-identical-helper-function.patch \
+    file://0004-route-use-the-new-helper-function-for-comparing-next.patch \
+    file://0005-link-bonding-parse-and-expose-bonding-options.patch \
+    file://0006-WIP-add-info-slave-data-support.patch \
+    file://0007-link-bonding-expose-state-on-enslaved-interfaces.patch \
+    file://0008-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
+    file://0009-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
+    file://0010-link-ignore-incomplete-bridge-updates.patch \
 "
 
 # commit hash of release tag libnl3_8_0


### PR DESCRIPTION
Backport the fix for updated object notifications, where the update was accidentially set to the update, not the updated object.

This fixes incomplete ecmp route update notifications.