### PR TITLE
Update onie-bisdn-upgrade documentation to warn about file loss

### DIFF
--- a/recipes-extended/man-pages/files/onie-bisdn-upgrade.1
+++ b/recipes-extended/man-pages/files/onie-bisdn-upgrade.1
@@ -9,7 +9,40 @@ onie-bisdn-upgrade \- upgrade or reinstall BISDN Linux
 [\fI\,OPTION\/\fR] [\fI\,IMAGEURL\/\fR]
 .SH DESCRIPTION
 .PP
-\fIonie-bisdn-upgrade\fP will upgrade BISDN Linux.
+\fIonie-bisdn-upgrade\fP initiates the installation of a new BISDN
+Linux image on the switch.
+
+The storage device is erased during the upgrade process. All files not
+explicitly configured for retention will be deleted.
+
+BISDN Linux has a backup configuration file, to keep specified user files
+during the upgrade process.
+
+To list files that will be preserved, run the following command:
+
+.RS
+.nf
+\fIgrep -hv "^#" /var/lib/opkg/info/*.conffiles /etc/default/{system,user}-backup.txt\fP
+.fi
+.RE
+
+Each line contains the path to a file (or directory) that should be kept,
+unless the line starts with the \fI-\fP character which indicates that
+the file should be deleted.
+
+Files are only kept if they are listed in the above output without the
+leading \fI-\fP.
+
+Note: deletion takes precedence, files and subdirectories cannot be included
+from a path marked for deletion.
+
+To add a file to the list of retained files, add the path to the file to
+\fI\%/etc/default/user-backup.txt\fP.
+
+Any symbolic links listed in user-backup.txt will be ignored. Symlinks
+within included directories will be kept.
+
+.SH OPTIONS
 .TP
 [\fI\,IMAGEURL\/\fR]
 .nf

--- a/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
+++ b/recipes-extended/onie-tools/onie-tools/onie-bisdn-upgrade
@@ -18,6 +18,8 @@ usage: $(basename "$0") [OPTIONS] [IMAGEURL]
 
 Example usage:
 $(basename "$0") http://repo.bisdn.de/pub/onie/generic-x86-64/onie-bisdn-generic-armel-iproc-v5.1.1.bin
+
+For additional information, see the man page for onie-bisdn-upgrade(1).
 "
 
 NEED_CONFIRM=true
@@ -54,7 +56,16 @@ case $# in
 esac;
 
 if [ "${NEED_CONFIRM}" = true ]; then
-  read -p "Upgrading BISDN Linux to install-source: ${INSTALL_FILE} using Client-IP-cfg: dhcp! Please confirm system reboot: [y/N] " yn
+  cat << EOF
+Upgrading BISDN Linux from ${INSTALL_FILE}.
+
+############################################################################
+# ONLY FILES CONFIGURED FOR RETENTION WILL BE KEPT!                        #
+#                                                                          #
+# For additional information, see the man page for onie-bisdn-upgrade(1).  #
+############################################################################
+EOF
+  read -p "Reboot the system and upgrade BISDN Linux? [y/N] " yn
   case $yn in
     [Yy]* ) ;;
     * ) echo "Operation aborted.";


### PR DESCRIPTION
When run without -d, onie-bisdn-upgrade offers this warning:

`Upgrading BISDN Linux to install-source: <URL> using Client-IP-cfg: dhcp! Please confirm system reboot: [y/N]`

The reboot should be rather obvious when installing a new operating system. However, upgrading BISDN Linux will preserve files only if they are listed in `/var/lib/opkg/info/*.conffiles` or
`/etc/default/{system,user}-backup.txt`. [1]

This change updates the script and its man page to warn prominently about the potential loss of files the user may want to keep.

[1] https://docs.bisdn.de/getting_started/install_bisdn_linux.html#backup-filesfolders-across-installations