### PR TITLE
cleanup and update distro features

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -12,7 +12,7 @@ FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
 FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/main/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci systemd usbhost virtualization xattr"
+DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci systemd usbhost vfat virtualization xattr"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"

--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -23,7 +23,7 @@ PREFERRED_PROVIDER_udev ?= "systemd"
 PREFERRED_PROVIDER_udev-utils ?= "systemd"
 
 BAD_RECOMMENDATIONS ?= "busybox-syslog"
-DISTRO_FEATURES:remove = "alsa"
+DISTRO_FEATURES:remove = "alsa opengl wayland vulkan"
 
 # disable symlinking of /var/volatile to /var/log to enable persistent logs
 VOLATILE_LOG_DIR = "no"

--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -12,7 +12,7 @@ FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
 FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/main/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci pcmcia systemd usbgadget usbhost virtualization xattr"
+DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci systemd usbgadget usbhost virtualization xattr"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"

--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -15,7 +15,7 @@ FEEDDOMAIN     ??= "http://repo.bisdn.de"
 DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci pcmcia systemd usbgadget usbhost virtualization xattr"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
-DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"
 VIRTUAL-RUNTIME_initscripts = ""
 
 VIRTUAL-RUNTIME_login_manager = "systemd"

--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -12,7 +12,7 @@ FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
 FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/main/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci systemd usbgadget usbhost virtualization xattr"
+DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci systemd usbhost virtualization xattr"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"


### PR DESCRIPTION
Cleanup and update distro features to match more what devices we target:

- disable pulseaudio support (no audio)
- disable wayland, vulkan, opengl (no video)
- disable pcmcia (we're not that ancient)
- disable usb gadget (we're not that embedded)
- enable vfat (mostly enables mkfs.vfat)

No substantial changes in the image, just a clean up.