### PR TITLE
installer: indicate when rootfs is getting written

### DIFF
--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -394,6 +394,7 @@ mount -t $fs_type -o defaults,rw $bisdn_linux_dev $bisdn_linux_mnt || {
 }
 
 # install fs
+echo "Writing root file system to $bisdn_linux_dev..."
 if [ -f rootfs.cpio.gz ] ; then
     image_archive=$(realpath rootfs.cpio.gz)
     cd $bisdn_linux_mnt
@@ -405,6 +406,7 @@ else
     echo "Error: Invalid root fs" >&2
     exit 1
 fi
+echo "Finished writing root file system."
 
 # store installation log in BISDN Linux file system (/onie-support-*.tar.bz2)
 onie-support $bisdn_linux_mnt


### PR DESCRIPTION
The step that takes longer than any other step of the install process should have a presence in the log file. With this change, the user will no longer wonder what the installer is doing for what can be almost 3 minutes on slower platforms.

With the change, the log will look something like this:

```
Writing superblocks and filesystem accounting information: done

Writing root file system: done
Success: Support tarball created: /tmp/tmp.wzusn1/onie-support.tar.bz2
```
