### PR TITLE
libnl: fix cloning links with slave ops

### DIFF
--- a/recipes-support/libnl/libnl/0006-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0006-WIP-add-info-slave-data-support.patch
@@ -1,18 +1,18 @@
-From e0825cfdebf8418ef4b27ebc140cdec35df9ebc1 Mon Sep 17 00:00:00 2001
+From dde4126e8ee58f5accb87f45bc53a07748d8cbe4 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
 Subject: [PATCH 06/10] WIP: add info slave data support
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
- lib/route/link.c          | 66 +++++++++++++++++++++++++++++++++++++++
- lib/route/link/api.c      | 22 +++++++++++++
- lib/route/link/link-api.h | 36 +++++++++++++++++++++
+ lib/route/link.c          | 71 +++++++++++++++++++++++++++++++++++++++
+ lib/route/link/api.c      | 22 ++++++++++++
+ lib/route/link/link-api.h | 36 ++++++++++++++++++++
  lib/route/nl-route.h      |  2 ++
- 4 files changed, 126 insertions(+)
+ 4 files changed, 131 insertions(+)
 
 diff --git a/lib/route/link.c b/lib/route/link.c
-index ce1355b991f2..e33bb3ab61c3 100644
+index ce1355b991f2..d325deced80a 100644
 --- a/lib/route/link.c
 +++ b/lib/route/link.c
 @@ -259,12 +259,29 @@ static void release_link_info(struct rtnl_link *link)
@@ -45,20 +45,25 @@ index ce1355b991f2..e33bb3ab61c3 100644
  
  		/* proto info af reference */
  		rtnl_link_af_ops_put(link->l_af_ops);
-@@ -337,6 +354,12 @@ static int link_clone(struct nl_object *_dst, struct nl_object *_src)
+@@ -337,6 +354,17 @@ static int link_clone(struct nl_object *_dst, struct nl_object *_src)
  		}
  	}
  
-+	if (src->l_info_slave_ops && src->l_info_ops->io_slave_clone) {
-+		err = src->l_info_slave_ops->io_slave_clone(dst, src);
-+		if (err < 0)
-+			return err;
++	if (src->l_info_slave_ops) {
++		rtnl_link_info_ops_get(src->l_info_slave_ops);
++		dst->l_info_slave_ops = src->l_info_slave_ops;
++
++		if (src->l_info_slave_ops->io_slave_clone) {
++			err = src->l_info_slave_ops->io_slave_clone(dst, src);
++			if (err < 0)
++				return err;
++		}
 +	}
 +
  	if ((err = do_foreach_af(src, af_clone, dst)) < 0)
  		return err;
  
-@@ -397,6 +420,8 @@ static struct nla_policy link_info_policy[IFLA_INFO_MAX+1] = {
+@@ -397,6 +425,8 @@ static struct nla_policy link_info_policy[IFLA_INFO_MAX+1] = {
  	[IFLA_INFO_KIND]	= { .type = NLA_STRING },
  	[IFLA_INFO_DATA]	= { .type = NLA_NESTED },
  	[IFLA_INFO_XSTATS]	= { .type = NLA_NESTED },
@@ -67,7 +72,7 @@ index ce1355b991f2..e33bb3ab61c3 100644
  };
  
  int rtnl_link_info_parse(struct rtnl_link *link, struct nlattr **tb)
-@@ -703,12 +728,27 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
+@@ -703,12 +733,27 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
  		}
  
  		if (li[IFLA_INFO_SLAVE_KIND]) {
@@ -95,7 +100,7 @@ index ce1355b991f2..e33bb3ab61c3 100644
  			link->ce_mask |= LINK_ATTR_LINKINFO_SLAVE_KIND;
  		}
  	}
-@@ -898,6 +938,9 @@ static void link_dump_line(struct nl_object *obj, struct nl_dump_params *p)
+@@ -898,6 +943,9 @@ static void link_dump_line(struct nl_object *obj, struct nl_dump_params *p)
  	if (link->l_info_ops && link->l_info_ops->io_dump[NL_DUMP_LINE])
  		link->l_info_ops->io_dump[NL_DUMP_LINE](link, p);
  
@@ -105,7 +110,7 @@ index ce1355b991f2..e33bb3ab61c3 100644
  	do_foreach_af(link, af_dump_line, p);
  
  	nl_dump(p, "\n");
-@@ -1159,6 +1202,7 @@ static uint64_t link_compare(struct nl_object *_a, struct nl_object *_b,
+@@ -1159,6 +1207,7 @@ static uint64_t link_compare(struct nl_object *_a, struct nl_object *_b,
  	}
  
  	diff |= _DIFF(LINK_ATTR_LINKINFO, rtnl_link_info_data_compare(a, b, flags) != 0);
@@ -113,7 +118,7 @@ index ce1355b991f2..e33bb3ab61c3 100644
  out:
  	return diff;
  
-@@ -1612,6 +1656,12 @@ static int build_link_msg(int cmd, struct ifinfomsg *hdr,
+@@ -1612,6 +1661,12 @@ static int build_link_msg(int cmd, struct ifinfomsg *hdr,
  
  		if (link->ce_mask & LINK_ATTR_LINKINFO_SLAVE_KIND) {
  			NLA_PUT_STRING(msg, IFLA_INFO_SLAVE_KIND, link->l_info_slave_kind);
@@ -126,7 +131,7 @@ index ce1355b991f2..e33bb3ab61c3 100644
  		}
  
  		nla_nest_end(msg, info);
-@@ -2613,6 +2663,8 @@ char *rtnl_link_get_type(struct rtnl_link *link)
+@@ -2613,6 +2668,8 @@ char *rtnl_link_get_type(struct rtnl_link *link)
  int rtnl_link_set_slave_type(struct rtnl_link *link, const char *type)
  {
  	char *kind = NULL;
@@ -135,7 +140,7 @@ index ce1355b991f2..e33bb3ab61c3 100644
  
  	if (type) {
  		kind = strdup(type);
-@@ -2622,12 +2674,26 @@ int rtnl_link_set_slave_type(struct rtnl_link *link, const char *type)
+@@ -2622,12 +2679,26 @@ int rtnl_link_set_slave_type(struct rtnl_link *link, const char *type)
  
  	free(link->l_info_slave_kind);
  	link->l_info_slave_kind = kind;

--- a/recipes-support/libnl/libnl/0007-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0007-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,4 +1,4 @@
-From a1e7c1c15982083bbcb68bcfb01e239ebbbd270b Mon Sep 17 00:00:00 2001
+From 253d75558c50689ab5251829b480b386851db845 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
 Subject: [PATCH 07/10] link/bonding: expose state on enslaved interfaces

--- a/recipes-support/libnl/libnl/0008-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0008-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,4 +1,4 @@
-From 6099d435b4c1784cf416c1b76704b364c5fa7e01 Mon Sep 17 00:00:00 2001
+From 9416344f29401aa585e26e36a2814f56824aba52 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
 Subject: [PATCH 08/10] bridge-vlan: add per vlan stp state object and cache

--- a/recipes-support/libnl/libnl/0009-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0009-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,4 +1,4 @@
-From c5235774783a9307fc044488f8576bd5bd87d113 Mon Sep 17 00:00:00 2001
+From 8e1f89cbaf90b5b0938b8091df5211f6bd809d0d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 1 Mar 2022 12:59:50 +0100
 Subject: [PATCH 09/10] route/route_obj: treat each IPv6 link-local route as

--- a/recipes-support/libnl/libnl/0010-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0010-link-ignore-incomplete-bridge-updates.patch
@@ -1,4 +1,4 @@
-From 6f57f9f19b672897214eefe86c01ec2aa109d53d Mon Sep 17 00:00:00 2001
+From 76b5b2e3874b86f07d0e8f20b37f2591c8818774 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 24 Apr 2024 14:13:22 +0200
 Subject: [PATCH 10/10] link: ignore incomplete bridge updates
@@ -50,10 +50,10 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 7 insertions(+)
 
 diff --git a/lib/route/link.c b/lib/route/link.c
-index e33bb3ab61c3..631ca42c1a7c 100644
+index d325deced80a..6f657bb7cbbd 100644
 --- a/lib/route/link.c
 +++ b/lib/route/link.c
-@@ -753,6 +753,13 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
+@@ -758,6 +758,13 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
  		}
  	}
  

--- a/recipes-support/libnl/libnl_3.8.0.bb
+++ b/recipes-support/libnl/libnl_3.8.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r4"
+PR = "r5"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"


### PR DESCRIPTION
Fix cloning links with slave ops. This fixes a crash when trying to clone a link with slave ops but not standard link ops, and now properly propagates the ops, as well as ups the reference.

Fixes: d116d6d8bba5 ("libnl: add slave data support")