### PR TITLE
libnl: update to 3.9.0

### DIFF
--- a/recipes-support/libnl/libnl/0001-cache-fix-new-object-in-callback-v2-on-updated-objec.patch
+++ b/recipes-support/libnl/libnl/0001-cache-fix-new-object-in-callback-v2-on-updated-objec.patch
@@ -1,4 +1,4 @@
-From b6f7c5fbd6b0f5649d54804acb56c4b95db0fae9 Mon Sep 17 00:00:00 2001
+From 71c8836eff748c9811ac6534ee5f5c15cdf4404d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 26 Apr 2024 16:32:21 +0200
 Subject: [PATCH 01/10] cache: fix new object in callback v2 on updated objects
@@ -36,5 +36,5 @@ index dd059c11e1a8..bae641ded565 100644
  					nl_object_put(clone);
  				} else if (cb)
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0002-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch
+++ b/recipes-support/libnl/libnl/0002-route-fix-IPv6-ecmp-route-deleted-nexthop-matching.patch
@@ -1,4 +1,4 @@
-From aa91e496249d0942c4287f7ac576dfc9b209d26f Mon Sep 17 00:00:00 2001
+From 259d0111a8e6ab2cf428e7788e8dc2f674ed0e2d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 30 Apr 2024 14:05:33 +0200
 Subject: [PATCH 02/10] route: fix IPv6 ecmp route deleted nexthop matching
@@ -59,5 +59,5 @@ index ce68259c30dc..cf538db93680 100644
  				rtnl_route_remove_nexthop(old_route, old_nh);
  
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0003-nexthop-add-a-identical-helper-function.patch
+++ b/recipes-support/libnl/libnl/0003-nexthop-add-a-identical-helper-function.patch
@@ -1,4 +1,4 @@
-From 87d4026cb13a1d05b222c0aadee4cf85422f49dd Mon Sep 17 00:00:00 2001
+From 6e8d8feed2e5d6abc82f51336ecd386da6bee9df Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 May 2024 14:00:39 +0200
 Subject: [PATCH 03/10] nexthop: add a identical helper function
@@ -15,7 +15,7 @@ nl_object_identical(), so add a separate identical helper function which
 compares only fixed attributes.
 
 Upstream-Status: Backport [https://github.com/thom311/libnl/commit/8cf29d7b4a8f4dadcc68932edc23e05f5d0fee89]
-[jonas.gorski: adapted for libnl 3.8]
+[jonas.gorski: adapted for libnl 3.9]
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  include/netlink/route/nexthop.h |  3 +++
@@ -66,18 +66,18 @@ index 962f2bab59c8..7e0df6136b04 100644
  {
  	struct nl_cache *link_cache;
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index 7e36de1eb28c..e36175b500a6 100644
+index fa7af4551495..a97ff3f74475 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1306,3 +1306,8 @@ global:
- 	rtnl_nh_set_fdb;
- 	rtnl_nh_set_gateway;
- } libnl_3_7;
+@@ -1314,3 +1314,8 @@ global:
+ 	rtnl_link_bond_set_min_links;
+ 	rtnl_link_can_get_device_stats;
+ } libnl_3_8;
 +
-+libnl_3_9 {
++libnl_3_10 {
 +global:
 +	rtnl_route_nh_identical;
-+} libnl_3_8;
++} libnl_3_9;
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0004-route-use-the-new-helper-function-for-comparing-next.patch
+++ b/recipes-support/libnl/libnl/0004-route-use-the-new-helper-function-for-comparing-next.patch
@@ -1,4 +1,4 @@
-From 490b8a8a27d62bd37f31d08cbfc4d4caa3f2ca51 Mon Sep 17 00:00:00 2001
+From 6a865688445448396aef5e46192034f1571c35a3 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 May 2024 14:06:48 +0200
 Subject: [PATCH 04/10] route: use the new helper function for comparing
@@ -71,5 +71,5 @@ index cf538db93680..6d36f80d2e13 100644
  				rtnl_route_remove_nexthop(old_route, old_nh);
  
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0005-link-bonding-parse-and-expose-bonding-options.patch
+++ b/recipes-support/libnl/libnl/0005-link-bonding-parse-and-expose-bonding-options.patch
@@ -1,20 +1,20 @@
-From 6927bcefbfc3e853bd7073ac997eb581e1bb2189 Mon Sep 17 00:00:00 2001
+From 638761201439eaa8fcaa44fad37744fd4528391a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 10:00:37 +0200
 Subject: [PATCH 05/10] link/bonding: parse and expose bonding options
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
- include/netlink/route/link/bonding.h |   9 +
- lib/route/link/bonding.c             | 235 ++++++++++++++++++++++++++-
+ include/netlink/route/link/bonding.h |   8 +
+ lib/route/link/bonding.c             | 223 +++++++++++++++++++++++++--
  libnl-route-3.sym                    |   6 +
- 3 files changed, 243 insertions(+), 7 deletions(-)
+ 3 files changed, 226 insertions(+), 11 deletions(-)
 
 diff --git a/include/netlink/route/link/bonding.h b/include/netlink/route/link/bonding.h
-index e85b44a24b59..b64964c70b62 100644
+index e12d8a524658..dbd33222b26b 100644
 --- a/include/netlink/route/link/bonding.h
 +++ b/include/netlink/route/link/bonding.h
-@@ -26,7 +26,16 @@ extern int	rtnl_link_bond_release_ifindex(struct nl_sock *, int);
+@@ -26,11 +26,19 @@ extern int	rtnl_link_bond_release_ifindex(struct nl_sock *, int);
  extern int	rtnl_link_bond_release(struct nl_sock *, struct rtnl_link *);
  
  extern void	rtnl_link_bond_set_mode(struct rtnl_link *link, uint8_t mode);
@@ -23,40 +23,40 @@ index e85b44a24b59..b64964c70b62 100644
  extern void	rtnl_link_bond_set_activeslave(struct rtnl_link *link, int active_slave);
 +extern int	rtnl_link_bond_get_activeslave(struct rtnl_link *link, int *active_slave);
 +
+ extern void	rtnl_link_bond_set_hashing_type (struct rtnl_link *link, uint8_t type);
++extern int	rtnl_link_bond_get_hashing_type(struct rtnl_link *, uint8_t *type);
+ extern void	rtnl_link_bond_set_miimon (struct rtnl_link *link, uint32_t miimon);
+ extern void	rtnl_link_bond_set_min_links (struct rtnl_link *link, uint32_t min_links);
+ 
 +extern void	rtnl_link_bond_set_primary(struct rtnl_link *, int primary);
 +extern int	rtnl_link_bond_get_primary(struct rtnl_link *, int *primary);
 +
-+extern void	rtnl_link_bond_set_xmit_hash_policy(struct rtnl_link *, uint8_t policy);
-+extern int	rtnl_link_bond_get_xmit_hash_policy(struct rtnl_link *, uint8_t *policy);
- 
  #ifdef __cplusplus
  }
+ #endif
 diff --git a/lib/route/link/bonding.c b/lib/route/link/bonding.c
-index 640a62caca78..4ad1ee6f547d 100644
+index 63fd47499e25..2308e4cc3915 100644
 --- a/lib/route/link/bonding.c
 +++ b/lib/route/link/bonding.c
-@@ -22,13 +22,17 @@
- #include "nl-route.h"
- #include "link-api.h"
- 
--#define BOND_HAS_MODE		(1 << 0)
--#define BOND_HAS_ACTIVE_SLAVE	(1 << 1)
-+#define BOND_HAS_MODE			(1 << 0)
-+#define BOND_HAS_ACTIVE_SLAVE		(1 << 1)
-+#define BOND_HAS_PRIMARY		(1 << 2)
-+#define BOND_HAS_XMIT_HASH_POLICY	(1 << 3)
+@@ -27,14 +27,16 @@
+ #define BOND_HAS_HASHING_TYPE	(1 << 2)
+ #define BOND_HAS_MIIMON		(1 << 3)
+ #define BOND_HAS_MIN_LINKS	(1 << 4)
++#define BOND_HAS_PRIMARY	(1 << 5)
  
  struct bond_info {
  	uint8_t bn_mode;
+ 	uint8_t hashing_type;
  	uint32_t ifindex;
 -	uint32_t bn_mask;
+ 	uint32_t miimon;
+ 	uint32_t min_links;
 +	uint32_t primary;
-+	uint8_t xmit_hash_policy;
 +	uint32_t ce_mask; /* HACK to support attr macros */
  };
  
  static int bond_info_alloc(struct rtnl_link *link)
-@@ -61,12 +65,18 @@ static int bond_put_attrs(struct nl_msg *msg, struct rtnl_link *link)
+@@ -67,21 +69,24 @@ static int bond_put_attrs(struct nl_msg *msg, struct rtnl_link *link)
  	data = nla_nest_start(msg, IFLA_INFO_DATA);
  	if (!data)
  		return -NLE_MSGSIZE;
@@ -68,16 +68,25 @@ index 640a62caca78..4ad1ee6f547d 100644
 +	if (bn->ce_mask & BOND_HAS_ACTIVE_SLAVE)
  		NLA_PUT_U32(msg, IFLA_BOND_ACTIVE_SLAVE, bn->ifindex);
  
+-	if (bn->bn_mask & BOND_HAS_HASHING_TYPE)
++	if (bn->ce_mask & BOND_HAS_HASHING_TYPE)
+ 		NLA_PUT_U8(msg, IFLA_BOND_XMIT_HASH_POLICY, bn->hashing_type);
+ 
+-	if (bn->bn_mask & BOND_HAS_MIIMON)
++	if (bn->ce_mask & BOND_HAS_MIIMON)
+ 		NLA_PUT_U32(msg, IFLA_BOND_MIIMON, bn->miimon);
+ 
+-	if (bn->bn_mask & BOND_HAS_MIN_LINKS)
++	if (bn->ce_mask & BOND_HAS_MIN_LINKS)
+ 		NLA_PUT_U32(msg, IFLA_BOND_MIN_LINKS, bn->min_links);
+ 
 +	if (bn->ce_mask & BOND_HAS_PRIMARY)
 +		NLA_PUT_U32(msg, IFLA_BOND_PRIMARY, bn->primary);
-+
-+	if (bn->ce_mask & BOND_HAS_XMIT_HASH_POLICY)
-+		NLA_PUT_U8(msg, IFLA_BOND_XMIT_HASH_POLICY, bn->xmit_hash_policy);
 +
  	nla_nest_end(msg, data);
  	return 0;
  
-@@ -75,11 +85,100 @@ nla_put_failure:
+@@ -90,11 +95,101 @@ nla_put_failure:
  	return -NLE_MSGSIZE;
  }
  
@@ -121,8 +130,8 @@ index 640a62caca78..4ad1ee6f547d 100644
 +	}
 +
 +	if (tb[IFLA_BOND_XMIT_HASH_POLICY]) {
-+		bn->xmit_hash_policy = nla_get_u32(tb[IFLA_BOND_XMIT_HASH_POLICY]);
-+		bn->ce_mask |= BOND_HAS_XMIT_HASH_POLICY;
++		bn->hashing_type = nla_get_u32(tb[IFLA_BOND_XMIT_HASH_POLICY]);
++		bn->ce_mask |= BOND_HAS_HASHING_TYPE;
 +	}
 +
 +	err = 0;
@@ -157,12 +166,13 @@ index 640a62caca78..4ad1ee6f547d 100644
 +	uint32_t attrs = flags & LOOSE_COMPARISON ? b->ce_mask : ~0;
 +
 +#define BOND_DIFF(ATTR, EXPR) ATTR_DIFF(attrs, BOND_HAS_##ATTR, a, b, EXPR)
++#define _DIFF(ATTR, EXPR) ATTR_DIFF(attrs, ATTR, a, b, EXPR)
 +
-+	diff |= BOND_DIFF(MODE, a->bn_mode != b->bn_mode);
-+	diff |= BOND_DIFF(ACTIVE_SLAVE, a->ifindex != b->ifindex);
-+	diff |= BOND_DIFF(PRIMARY, a->primary != b->primary);
-+	diff |= BOND_DIFF(XMIT_HASH_POLICY, a->xmit_hash_policy != b->xmit_hash_policy);
-+#undef BOND_DIFF
++	diff |= _DIFF(BOND_HAS_MODE, a->bn_mode != b->bn_mode);
++	diff |= _DIFF(BOND_HAS_ACTIVE_SLAVE, a->ifindex != b->ifindex);
++	diff |= _DIFF(BOND_HAS_PRIMARY, a->primary != b->primary);
++	diff |= _DIFF(BOND_HAS_HASHING_TYPE, a->hashing_type != b->hashing_type);
++#undef _DIFF
 +
 +	return diff;
 +}
@@ -178,7 +188,7 @@ index 640a62caca78..4ad1ee6f547d 100644
  };
  
  #define IS_BOND_INFO_ASSERT(link)                                                    \
-@@ -104,7 +203,29 @@ void rtnl_link_bond_set_activeslave(struct rtnl_link *link, int active_slave)
+@@ -119,7 +214,29 @@ void rtnl_link_bond_set_activeslave(struct rtnl_link *link, int active_slave)
  
  	bn->ifindex = active_slave;
  
@@ -209,7 +219,7 @@ index 640a62caca78..4ad1ee6f547d 100644
  }
  
  /**
-@@ -122,7 +243,107 @@ void rtnl_link_bond_set_mode(struct rtnl_link *link, uint8_t mode)
+@@ -137,7 +254,68 @@ void rtnl_link_bond_set_mode(struct rtnl_link *link, uint8_t mode)
  
  	bn->bn_mode = mode;
  
@@ -276,55 +286,66 @@ index 640a62caca78..4ad1ee6f547d 100644
 +		*primary = info->primary;
 +
 +	return 0;
+ }
+ 
+ /**
+@@ -155,7 +333,30 @@ void rtnl_link_bond_set_hashing_type (struct rtnl_link *link, uint8_t type)
+ 
+ 	bn->hashing_type = type;
+ 
+-	bn->bn_mask |= BOND_HAS_HASHING_TYPE;
++	bn->ce_mask |= BOND_HAS_HASHING_TYPE;
 +}
 +
 +/**
-+ * Set bond mode xmit hash policy
-+ * @arg link		Link object of type bond
-+ * @arg mode		bond xmit hash policy to set
 + *
-+ * @return void
-+ */
-+void rtnl_link_bond_set_xmit_hash_policy(struct rtnl_link *link, uint8_t policy)
-+{
-+	struct bond_info *info = link->l_info;
-+
-+	IS_BOND_INFO_ASSERT(link);
-+
-+	info->xmit_hash_policy = policy;
-+	info->ce_mask |= BOND_HAS_XMIT_HASH_POLICY;
-+}
-+
-+/**
-+ * Get bond mode xmit hash policy
++ * Get hashing type
 + * @arg link		Link object of type bond
-+ * @arg mode		bond xmit hash policy
++ * @arg mode		bond hashing type
 + *
 + * @return 0 on success or a negative error code
 + */
-+int rtnl_link_bond_get_xmit_hash_policy(struct rtnl_link *link, uint8_t *policy)
++int rtnl_link_bond_get_hashing_type(struct rtnl_link *link, uint8_t *type)
 +{
 +	struct bond_info *info = link->l_info;
 +
 +	IS_BOND_INFO_ASSERT(link);
 +
-+	if (!(info->ce_mask & BOND_HAS_XMIT_HASH_POLICY))
++	if (!(info->ce_mask & BOND_HAS_HASHING_TYPE))
 +		return -NLE_NOATTR;
 +
-+	if (policy)
-+		*policy = info->xmit_hash_policy;
++	if (type)
++		*type = info->hashing_type;
 +
 +	return 0;
  }
  
  /**
+@@ -173,7 +374,7 @@ void rtnl_link_bond_set_miimon (struct rtnl_link *link, uint32_t miimon)
+ 
+ 	bn->miimon = miimon;
+ 
+-	bn->bn_mask |= BOND_HAS_MIIMON;
++	bn->ce_mask |= BOND_HAS_MIIMON;
+ }
+ 
+ /**
+@@ -192,7 +393,7 @@ void rtnl_link_bond_set_min_links (struct rtnl_link *link, uint32_t min_links)
+ 
+ 	bn->min_links = min_links;
+ 
+-	bn->bn_mask |= BOND_HAS_MIN_LINKS;
++	bn->ce_mask |= BOND_HAS_MIN_LINKS;
+ }
+ 
+ /**
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index e36175b500a6..dee4c64094bb 100644
+index a97ff3f74475..c07bcc071613 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1309,5 +1309,11 @@ global:
+@@ -1317,5 +1317,11 @@ global:
  
- libnl_3_9 {
+ libnl_3_10 {
  global:
 +	rtnl_link_bond_get_activeslave;
 +	rtnl_link_bond_get_mode;
@@ -333,7 +354,7 @@ index e36175b500a6..dee4c64094bb 100644
 +	rtnl_link_bond_set_primary;
 +	rtnl_link_bond_set_xmit_hash_policy;
  	rtnl_route_nh_identical;
- } libnl_3_8;
+ } libnl_3_9;
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0006-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0006-WIP-add-info-slave-data-support.patch
@@ -1,4 +1,4 @@
-From dde4126e8ee58f5accb87f45bc53a07748d8cbe4 Mon Sep 17 00:00:00 2001
+From 75f439a3457ca3a7f5e1747492302abd30412be7 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
 Subject: [PATCH 06/10] WIP: add info slave data support
@@ -270,5 +270,5 @@ index 28d0166295e7..f559de40ace2 100644
  	uint32_t l_promiscuity;
  	uint32_t l_num_tx_queues;
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0007-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0007-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,4 +1,4 @@
-From 253d75558c50689ab5251829b480b386851db845 Mon Sep 17 00:00:00 2001
+From ef8b19ed89de79cae236e8d39829f8b4c56326d4 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
 Subject: [PATCH 07/10] link/bonding: expose state on enslaved interfaces
@@ -11,12 +11,12 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  3 files changed, 177 insertions(+)
 
 diff --git a/include/netlink/route/link/bonding.h b/include/netlink/route/link/bonding.h
-index b64964c70b62..36ca58aa60b4 100644
+index dbd33222b26b..730cda3416c0 100644
 --- a/include/netlink/route/link/bonding.h
 +++ b/include/netlink/route/link/bonding.h
-@@ -37,6 +37,9 @@ extern int	rtnl_link_bond_get_primary(struct rtnl_link *, int *primary);
- extern void	rtnl_link_bond_set_xmit_hash_policy(struct rtnl_link *, uint8_t policy);
- extern int	rtnl_link_bond_get_xmit_hash_policy(struct rtnl_link *, uint8_t *policy);
+@@ -39,6 +39,9 @@ extern void	rtnl_link_bond_set_min_links (struct rtnl_link *link, uint32_t min_l
+ extern void	rtnl_link_bond_set_primary(struct rtnl_link *, int primary);
+ extern int	rtnl_link_bond_get_primary(struct rtnl_link *, int *primary);
  
 +extern void	rtnl_link_bond_slave_set_state(struct rtnl_link *, uint8_t state);
 +extern int	rtnl_link_bond_slave_get_state(struct rtnl_link *, uint8_t *state);
@@ -25,10 +25,10 @@ index b64964c70b62..36ca58aa60b4 100644
  }
  #endif
 diff --git a/lib/route/link/bonding.c b/lib/route/link/bonding.c
-index 4ad1ee6f547d..a47871ee3e6a 100644
+index 2308e4cc3915..c56906362d6c 100644
 --- a/lib/route/link/bonding.c
 +++ b/lib/route/link/bonding.c
-@@ -171,6 +171,125 @@ static int bond_compare(struct rtnl_link *link_a, struct rtnl_link *link_b,
+@@ -182,6 +182,125 @@ static int bond_compare(struct rtnl_link *link_a, struct rtnl_link *link_b,
  	return diff;
  }
  
@@ -154,7 +154,7 @@ index 4ad1ee6f547d..a47871ee3e6a 100644
  static struct rtnl_link_info_ops bonding_info_ops = {
  	.io_name		= "bond",
  	.io_alloc		= bond_info_alloc,
-@@ -179,6 +298,15 @@ static struct rtnl_link_info_ops bonding_info_ops = {
+@@ -190,6 +309,15 @@ static struct rtnl_link_info_ops bonding_info_ops = {
  	.io_put_attrs		= bond_put_attrs,
  	.io_free		= bond_info_free,
  	.io_compare		= bond_compare,
@@ -170,7 +170,7 @@ index 4ad1ee6f547d..a47871ee3e6a 100644
  };
  
  #define IS_BOND_INFO_ASSERT(link)                                                    \
-@@ -346,6 +474,50 @@ int rtnl_link_bond_get_xmit_hash_policy(struct rtnl_link *link, uint8_t *policy)
+@@ -359,6 +487,50 @@ int rtnl_link_bond_get_hashing_type(struct rtnl_link *link, uint8_t *type)
  	return 0;
  }
  
@@ -219,20 +219,20 @@ index 4ad1ee6f547d..a47871ee3e6a 100644
 +}
 +
  /**
-  * Allocate link object of type bond
-  *
+  * Set MII monitoring interval
+  * @arg link            Link object of type bond
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index dee4c64094bb..f7017e161e43 100644
+index c07bcc071613..70ab31a2eef0 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1315,5 +1315,7 @@ global:
+@@ -1323,5 +1323,7 @@ global:
  	rtnl_link_bond_get_xmit_hash_policy;
  	rtnl_link_bond_set_primary;
  	rtnl_link_bond_set_xmit_hash_policy;
 +	rtnl_link_bond_slave_get_state;
 +	rtnl_link_bond_slave_set_state;
  	rtnl_route_nh_identical;
- } libnl_3_8;
+ } libnl_3_9;
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0008-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0008-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,4 +1,4 @@
-From 9416344f29401aa585e26e36a2814f56824aba52 Mon Sep 17 00:00:00 2001
+From cd48953535a8c54d01ce161223288b41cd91f192 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
 Subject: [PATCH 08/10] bridge-vlan: add per vlan stp state object and cache
@@ -38,7 +38,7 @@ index cb825cd0bbce..ae56d075718e 100644
  /src/nl-class-delete
  /src/nl-class-list
 diff --git a/Makefile.am b/Makefile.am
-index 29748d9beec0..09b50d63daef 100644
+index 1e766493b5f3..3805e25472f9 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -103,6 +103,7 @@ libnlinclude_netlink_routedir = $(libnlincludedir)/netlink/route
@@ -57,7 +57,7 @@ index 29748d9beec0..09b50d63daef 100644
  	include/netlink/cli/class.h \
  	include/netlink/cli/cls.h \
  	include/netlink/cli/ct.h \
-@@ -430,6 +432,7 @@ lib_libnl_route_3_la_SOURCES = \
+@@ -435,6 +437,7 @@ lib_libnl_route_3_la_SOURCES = \
  	lib/route/act/skbedit.c \
  	lib/route/act/vlan.c \
  	lib/route/addr.c \
@@ -65,7 +65,7 @@ index 29748d9beec0..09b50d63daef 100644
  	lib/route/class.c \
  	lib/route/classid.c \
  	lib/route/cls.c \
-@@ -683,6 +686,7 @@ endif
+@@ -688,6 +691,7 @@ endif
  
  src_lib_libnl_cli_3_la_SOURCES = \
  	src/lib/addr.c \
@@ -73,7 +73,7 @@ index 29748d9beec0..09b50d63daef 100644
  	src/lib/class.c \
  	src/lib/cls.c \
  	src/lib/ct.c \
-@@ -749,6 +753,7 @@ cli_programs = \
+@@ -754,6 +758,7 @@ cli_programs = \
  	src/nl-addr-add \
  	src/nl-addr-delete \
  	src/nl-addr-list \
@@ -81,7 +81,7 @@ index 29748d9beec0..09b50d63daef 100644
  	src/nl-class-add \
  	src/nl-class-delete \
  	src/nl-class-list \
-@@ -827,6 +832,8 @@ src_nl_addr_delete_CPPFLAGS =       $(src_cppflags)
+@@ -832,6 +837,8 @@ src_nl_addr_delete_CPPFLAGS =       $(src_cppflags)
  src_nl_addr_delete_LDADD =          $(src_ldadd)
  src_nl_addr_list_CPPFLAGS =         $(src_cppflags)
  src_nl_addr_list_LDADD =            $(src_ldadd)
@@ -589,11 +589,11 @@ index 75f03cd154af..bc10208c8459 100644
 +	nl_cli_bridge_vlan_parse_ifindex;
 +} libnl_3_8;
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index f7017e161e43..dac68eb65ef5 100644
+index 70ab31a2eef0..2842d6785234 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1310,6 +1310,19 @@ global:
- libnl_3_9 {
+@@ -1318,6 +1318,19 @@ global:
+ libnl_3_10 {
  global:
  	rtnl_link_bond_get_activeslave;
 +	rtnl_bridge_vlan_alloc;
@@ -718,5 +718,5 @@ index 60a02d2b49d4..c85d2323ac36 100644
  };
  
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0009-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0009-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,4 +1,4 @@
-From 8e1f89cbaf90b5b0938b8091df5211f6bd809d0d Mon Sep 17 00:00:00 2001
+From 0474e570fff610eb70adb62afb6ab63a33412096 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 1 Mar 2022 12:59:50 +0100
 Subject: [PATCH 09/10] route/route_obj: treat each IPv6 link-local route as
@@ -50,5 +50,5 @@ index 6d36f80d2e13..93f3d87b9c96 100644
  }
  
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl/0010-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0010-link-ignore-incomplete-bridge-updates.patch
@@ -1,4 +1,4 @@
-From 76b5b2e3874b86f07d0e8f20b37f2591c8818774 Mon Sep 17 00:00:00 2001
+From d0eeaa3f06a4c17b8ba940ab6bca61693cb994ef Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 24 Apr 2024 14:13:22 +0200
 Subject: [PATCH 10/10] link: ignore incomplete bridge updates
@@ -68,5 +68,5 @@ index d325deced80a..6f657bb7cbbd 100644
  	    && link->l_af_ops
  	    && link->l_af_ops->ao_parse_protinfo) {
 -- 
-2.45.0
+2.45.1
 

--- a/recipes-support/libnl/libnl_3.9.0.bb
+++ b/recipes-support/libnl/libnl_3.9.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r5"
+PR = "r1"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -26,8 +26,8 @@ SRC_URI = " \
     file://0010-link-ignore-incomplete-bridge-updates.patch \
 "
 
-# commit hash of release tag libnl3_8_0
-SRCREV = "6b2533c02813ce21b27ea8318fbe1af95652a39e"
+# commit hash of release tag libnl3_9_0
+SRCREV = "bdf83151326e365f137fe0e36dc9b1b7aeb1cf33"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update to libnl 3.9, which is mostly a bug fix release.

Most relevant change is that there was some bond link support added, so rebase our extension on top of it.

Full changelog:

    bdf83151326e libnl-3.9.0 release
    aa7353fde853 include/linux-private: import 'seg6 local' headers from kernel tree
    9466f680a58c lib: remove unused assignment in nl_addr_parse()
    acd05d6e8066 route/tc: avoid integer overflow in rtnl_tc_calc_cell_log()
    daa8efcb4c45 xfrm: return -NLE_MISSING_ATTR from xfrmnl_sa_get_auth_params()
    d8a1ff30c486 xfrm: fix leaking usertemplate in xfrmnl_sp_parse()
    4fcb075720ed socket: workaround coverity warning about time_t handling
    f743c62fa69e github: update Fedora image and version for clang-format
    f33e8cd68344 clang-format: rework container script
    aea3f9f2d8b6 lib: fix signed overflow warning in nl_object_diff()
    57e0170607a9 socket: explicitly cast time() to uint32_t
    46e8739ef708 src: fix leak in "nl-cls-add"
    a06c8f76c2ea route/cls: add get/take wrappers for rtnl_act_append()
    7912b4f90668 route/cls: fix leak in error handling of rtnl_flower_append_action()
    efd65feb9c3b route: fix just introduced use-after-free in rtnl_act_parse()
    105a6be10a5f route: use cleanup macro in rtnl_act_parse()
    78246da7bebb nl-aux-route: add cleanup macro for rtnl_act_put_all()
    72762b2006cd base: add _NL_AUTO_DEFINE_FCN_INDIRECT0() macro
    a70f789a79d7 route: fix memleak in rtnl_act_parse()
    65ab16f23b55 base: don't use static array indices for buffer argument of _nl_inet_ntop()
    444e2c04fec4 route/can: implement can_device_stats
    a4718e674724 github: build with "-fexceptions" CFLAGS
    30d6e63cc0b1 xfrm: erge branch 'th/xfrm-addr-cleanup'
    2f485cc7e4ff xfrm: refactor error handling in XFRM parsing
    01bd8fb01fb0 include: add "nl-aux-xfrm" helpers
    49c20efaa783 xfrm: fix crashes in case of ENOMEM
    9e7b5c86ce68 xfrm: refactor nl_addr_build() calls in XFRM code
    dbfd87b1d910 xfrm: use cleanup attribute for nl_addr in XFRM parsing
    db4248350184 xfrm: fix error code for NLE_ENOMEM in xfrmnl_ae_parse()
    9c97deff90b7 xfrm: fix parsing address in xfrmnl_ae_parse()
    8b6dc8348b03 nl-aux-core: add _nl_addr_build() helper
    057aac1334af nl-base-utils: add _nl_addr_family_to_size() helper
    cd4016bab267 xfrm: merge branch 'spellingmistake:main'
    664f8f1bea7f xfrm: clear XFRM_SP_ATTR_TMPL when removing the last template from a policy
    c4c22d267117 xfrm/sp: fix reference counters of sa selector/tmpl addresses
    5979fcb0a685 route/link: add bonding interface options set rtnl apis
    a735989cff55 build: fix declaring special targets as ".PHONY"
    052a97cb6554 Makefile.am: avoid use of non-portable echo arguments
    9aab12dff8e8 python: Use correct decorator syntax in HTBQdisc