### PR TITLE
include man pages for all components in full images

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -12,7 +12,7 @@ FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
 FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/main/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci systemd usbhost vfat virtualization xattr"
+DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci manpages systemd usbhost vfat virtualization xattr"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"

--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -3,7 +3,7 @@
 
 require minimal.bb
 
-IMAGE_FEATURES += " package-management"
+IMAGE_FEATURES += " doc-pkgs package-management"
 
 BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     baseboxd \


### PR DESCRIPTION
Enable the doc-pkgs image feature to automatically install man pages for
any package included in the image.

Increases the image size by about 11 MiB.