### PR TITLE
openssh: fix CVE-2024-6387

### DIFF
--- a/recipes-connectivity/openssh/openssh/CVE-2024-6387.patch
+++ b/recipes-connectivity/openssh/openssh/CVE-2024-6387.patch
@@ -1,0 +1,27 @@
+Description: fix signal handler race condition
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/2070497
+
+CVE: CVE-2024-6387
+
+Upstream-Status: Backport
+https://git.launchpad.net/ubuntu/+source/openssh/commit/?h=applied/ubuntu/jammy-devel&id=b059bcfa928df4ff2d103ae2e8f4e3136ee03efc
+
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+
+--- a/log.c
++++ b/log.c
+@@ -452,12 +452,14 @@ void
+ sshsigdie(const char *file, const char *func, int line, int showfunc,
+     LogLevel level, const char *suffix, const char *fmt, ...)
+ {
++#if 0
+ 	va_list args;
+ 
+ 	va_start(args, fmt);
+ 	sshlogv(file, func, line, showfunc, SYSLOG_LEVEL_FATAL,
+ 	    suffix, fmt, args);
+ 	va_end(args);
++#endif
+ 	_exit(1);
+ }
+ 

--- a/recipes-connectivity/openssh/openssh_8.9p1.bbappend
+++ b/recipes-connectivity/openssh/openssh_8.9p1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:append := ":${THISDIR}/openssh"
+
+SRC_URI:append = " \
+           file://CVE-2024-6387.patch \
+"


### PR DESCRIPTION
sshd(8) in Portable OpenSSH versions 8.5p1 to 9.7p1 (inclusive). Race condition resulting in potential remote code execution. A race condition in sshd(8) could allow remote code execution as root on non-OpenBSD systems. This attack could be prevented by disabling the login grace timeout (LoginGraceTime=0 in sshd_config) though this makes denial-of service against sshd(8) considerably easier. For more information, please refer to the release notes [1] and the report from the Qualys Security Advisory Team [2] who discovered the bug.

[1] https://www.openssh.com/txt/release-9.8
[2] https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt

References:
https://www.openssh.com/security.html


[jonas.gorski: convert to bbappend]