### PR TITLE
onie-nos-installer: fix sstate skip override syntax

### DIFF
--- a/recipes-core/images/onie-nos-installer.inc
+++ b/recipes-core/images/onie-nos-installer.inc
@@ -61,7 +61,7 @@ do_onie_bundle () {
     ln -sf "./onie-bisdn-${IMAGE_NAME}.bin" "./onie-bisdn-${IMAGE_LINK_NAME}.bin"
 }
 
-SSTATE_SKIP_CREATION_task-onie-bundle = '0'
+SSTATE_SKIP_CREATION:task-onie-bundle = '0'
 
 addtask do_onie_bundle after do_image_complete before do_build
 


### PR DESCRIPTION
SSTATE_SKIP_CREATION also needs the new override syntax, but was missed when updating the layer for kirkstone.

Should silence spurious warnings about changing sstate hashes on subsequent image builds with the same source tree.

Fixes: c3425e295236 ("update layer to kirkstone")