### PR TITLE
installer: add globbing for backup configuration

### DIFF
--- a/recipes-core/base-files/base-files/user-backup.txt
+++ b/recipes-core/base-files/base-files/user-backup.txt
@@ -5,6 +5,7 @@
 # 
 # - absolute paths to files or directories to keep:
 # e.g. "/etc/default/user-backup.txt"
+# or, using wildcards: "/home/*/.ssh/"
 #
 # - prefixed paths with a "-" for configuration files to NOT keep:
 # e.g. "-/etc/hostname"
@@ -12,7 +13,6 @@
 # - comments, like this block, prefixed with #.
 #
 # Limitations:
-# - You cannot use wildcards.
 # - Symlinks are not supported and will be ignored.
 # - Do NOT keep ("-") has higher priority than keep. When both are
 #   present, the file will not be kept, regardless of the order.

--- a/scripts/installer/lib/backup.sh
+++ b/scripts/installer/lib/backup.sh
@@ -98,6 +98,8 @@ parse_file() {
 		return 0
 	fi
 
+	# Switch to src directory to make globbing (wildcard expansion) work
+	cd "$3" || exit 1
 	while read -r line; do
 		case "$line" in
 		"#"*)
@@ -105,16 +107,22 @@ parse_file() {
 			;;
 		"-"*)
 			if [ "$2" = "-" ]; then
-				remove_from_backup "${line:1}" $3 $4
+				# Globbing after removing the leading '-'
+				for fpath in ./${line:1}; do
+					remove_from_backup "${fpath}" $3 $4
+				done
 			fi
 			;;
 		/*)
 			if [ "$2" = "+" ]; then
-				add_to_backup "$line" $3 $4
+				for fpath in ./${line}; do
+					add_to_backup "$fpath" $3 $4
+				done
 			fi
 			;;
 		esac
 	done < $1
+	cd -
 }
 
 # $1 src $2 dst


### PR DESCRIPTION
Globbing can be quite useful when selecting the paths to preserve across operating system updates. So far, the backup/restore mechanism did not support wildcards. This change enables globbing as supported by the busybox /bin/sh.

Note that the code is intentionally kept simple; among other things, busybox sh does not support pushd and arrays.