### PR TITLE
switch_tcpdump: break out of loop after terminating tcpdump

### DIFF
--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -260,6 +260,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                     time.time() - starting_time > timeoutSeconds):
                 tcpdumpProcess.terminate()
                 print("Reached capture timeout, stopping")
+                break
 
             if (maxSizeMB
                     and filePath
@@ -267,6 +268,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                     and int(os.path.getsize(filePath) / 1e6) > maxSizeMB):
                 tcpdumpProcess.terminate()
                 print("Max file size reached, stopping")
+                break
 
     except KeyboardInterrupt:
         tcpdumpProcess.terminate()


### PR DESCRIPTION
Once we have decided to terminate the tcpdump subprocess, we should break out of the loop instead of staying and trying to terminate the process until it is gone.

This should fix switch_tcpdump sometimes showing multiple "Reached capture timeout, stopping" messages in a row.