### PR TITLE
conf: rename layer matching the repository

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 This README file contains information on the contents of the
-meta-switch layer.
+meta-bisdn-linux layer.
 
 Please see the corresponding sections below for details.
 
@@ -19,26 +19,26 @@ This layer depends on:
 Table of Contents
 =================
 
-  I. Adding the meta-switch layer to your build
+  I. Adding the meta-bisdn-linux layer to your build
  II. Misc
 
 
-I. Adding the meta-switch layer to your build
+I. Adding the meta-bisdn-linux layer to your build
 =================================================
 
 In order to use this layer, you need to make the build system aware of
 it.
 
-Assuming the meta-switch layer exists at the top-level of your
+Assuming the meta-bisdn-linux layer exists at the top-level of your
 yocto build tree, you can add it to the build system by adding the
-location of the meta-switch layer to bblayers.conf, along with any
+location of the meta-bisdn-linux layer to bblayers.conf, along with any
 other layers needed. e.g.:
 
   BBLAYERS ?= " \
     /path/to/yocto/meta \
     /path/to/yocto/meta-yocto \
     /path/to/yocto/meta-yocto-bsp \
-    /path/to/yocto/meta-meta-switch \
+    /path/to/yocto/meta-meta-bisdn-linux \
     "
 
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,13 +5,13 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 	${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "meta-switch"
-BBFILE_PATTERN_meta-switch = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-switch = "9"
+BBFILE_COLLECTIONS += "bisdn-linux-layer"
+BBFILE_PATTERN_bisdn-linux-layer = "^${LAYERDIR}/"
+BBFILE_PRIORITY_bisdn-linux-layer = "9"
 
-LAYERVERSION_meta-switch = "1"
+LAYERVERSION_bisdn-linux-layer = "1"
 
-LAYERDEPENDS_meta-switch = " \
+LAYERDEPENDS_bisdn-linux-layer = " \
   core \
   filesystems-layer \
   meta-python \
@@ -22,4 +22,4 @@ LAYERDEPENDS_meta-switch = " \
   webserver \
 "
 
-LAYERSERIES_COMPAT_meta-switch = "kirkstone"
+LAYERSERIES_COMPAT_bisdn-linux-layer = "kirkstone"

--- a/recipes-extended/man-pages/files/onie-bisdn-upgrade.1
+++ b/recipes-extended/man-pages/files/onie-bisdn-upgrade.1
@@ -1,5 +1,5 @@
 .\" Manpage for onie-bisdn-upgrade.
-.\" File an issue at https://github.com/bisdn/meta-switch/issues to correct
+.\" File an issue at https://github.com/bisdn/meta-bisdn-linux/issues to correct
 .\" errors or typos.
 .TH ONIE-BISDN-UPGRADE 8 "23 May 2024" "" "BISDN Linux User Manual"
 .SH NAME


### PR DESCRIPTION
With the rename of the repository to meta-bisdn-linux we should also rename the layer itself. The common pattern is meta-XXX is named XXX-layer, so rename the layer accordingly.

Also update all references to meta-switch accordingly.