### PR TITLE
hostapd: 802.1x authentication fixes

### DIFF
--- a/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
+++ b/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
@@ -1,7 +1,7 @@
 From a93fd09c848a181aecaea0c84a0b64e2612075c2 Mon Sep 17 00:00:00 2001
 From: Jouni Malinen <j@w1.fi>
 Date: Sun, 17 Dec 2023 14:09:57 +0200
-Subject: [PATCH 01/10] Split ap_sta_set_authorized() into two steps
+Subject: [PATCH 01/11] Split ap_sta_set_authorized() into two steps
 
 This function is both updating the hostapd-internal sta->flags value and
 sending out the AP-STA-CONNECTED control interface message. When

--- a/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
+++ b/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
@@ -1,7 +1,7 @@
 From 0c14202044d7b10f0a1ed1cffa05068e91c8c75e Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 Jan 2025 11:10:41 +0100
-Subject: [PATCH 02/10] netlink: allow listening for neighbor events
+Subject: [PATCH 02/11] netlink: allow listening for neighbor events
 
 Similar how subscribing to link events works, allow subscribing to
 neighbor events, but only subscribe if any callbacks are populated.

--- a/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
+++ b/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
@@ -1,7 +1,7 @@
 From 55ad721b3e8cc75870f4e0bc1bf0712a0768fc09 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 20 Jan 2025 09:07:56 +0100
-Subject: [PATCH 03/10] add wired driver extra options
+Subject: [PATCH 03/11] add wired driver extra options
 
 Add two options for for driver_wired_linux:
 

--- a/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
+++ b/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
@@ -1,7 +1,7 @@
 From 64c83efde9a4fce302913ab12bcd7e40d2479541 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 12 Feb 2025 10:49:28 +0100
-Subject: [PATCH 04/10] import base MAB handling code from Cumulus
+Subject: [PATCH 04/11] import base MAB handling code from Cumulus
 
 Import base MAB handling code from Cumulus:
 

--- a/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
+++ b/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
@@ -1,7 +1,7 @@
 From e4e892771d631104476455ef95c41bfe72ffd20b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 14 Feb 2025 10:52:51 +0100
-Subject: [PATCH 05/10] use a timer for mab instead of forcing drivers to set
+Subject: [PATCH 05/11] use a timer for mab instead of forcing drivers to set
  it explicitly
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

--- a/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
+++ b/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
@@ -1,7 +1,7 @@
 From 48f06fe5d5774037d623ea353e49e9e3357b8618 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 Jan 2025 13:04:48 +0100
-Subject: [PATCH 06/10] drivers: add a linux wired driver
+Subject: [PATCH 06/11] drivers: add a linux wired driver
 
 Add a driver making use of the new-ish LOCKED flags for ports and
 neighbors to implement a wired driver for linux.

--- a/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
+++ b/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
@@ -1,7 +1,7 @@
 From a5ef112d767f7e79c396b5d21982c63d4f919a28 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 14 Feb 2025 10:59:57 +0100
-Subject: [PATCH 07/10] driver_linux_wired: handle neighs going away
+Subject: [PATCH 07/11] driver_linux_wired: handle neighs going away
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---

--- a/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
+++ b/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
@@ -1,7 +1,7 @@
 From 88fa44e53f3412c5c105f650ff9365f90ce49b50 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 17 Feb 2025 14:14:16 +0100
-Subject: [PATCH 08/10] driver_wired_linux: flush all entries on start/stop
+Subject: [PATCH 08/11] driver_wired_linux: flush all entries on start/stop
 
 Make sure that there are no fdb entries left on start or stop that may
 unlock traffic unexpectedly.

--- a/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
+++ b/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
@@ -1,7 +1,7 @@
 From 0750ee63edf16e431d82c205ada10bc468e3d19b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 17 Feb 2025 14:36:36 +0100
-Subject: [PATCH 09/10] driver_wired_linux: wait for bridge attachment
+Subject: [PATCH 09/11] driver_wired_linux: wait for bridge attachment
 
 If bridge assignment happens in parallel to hostapd bring up, the
 interface may not yet be attached to the bridge when hostapd tries to

--- a/recipes-connectivity/hostapd/files/0010-driver_wired_linux-unlock-neigh-before-unlocking-por.patch
+++ b/recipes-connectivity/hostapd/files/0010-driver_wired_linux-unlock-neigh-before-unlocking-por.patch
@@ -1,7 +1,7 @@
 From 3e2ce55a34681a29dc96b36317e27c615bb33b63 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 24 Jul 2025 14:52:53 +0200
-Subject: [PATCH 10/10] driver_wired_linux: unlock neigh before unlocking port
+Subject: [PATCH 10/11] driver_wired_linux: unlock neigh before unlocking port
 
 Unlocking a port will flush all present locked neighs, which will
 trigger us reporting the STA as left, causing hostapd to immediately

--- a/recipes-connectivity/hostapd/files/0011-driver_wired_linux-add-ifname-to-log-messages.patch
+++ b/recipes-connectivity/hostapd/files/0011-driver_wired_linux-add-ifname-to-log-messages.patch
@@ -1,0 +1,181 @@
+From acef9009f9b27a58a116bcfef316b60a2bda5730 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Thu, 24 Jul 2025 16:31:34 +0200
+Subject: [PATCH 11/11] driver_wired_linux: add ifname to log messages
+
+Prefix log messages with the interface name, matching other places in
+hostapd that print messages.
+
+Should make it clearer where things are happening when running auth on
+multiple ports.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ src/drivers/driver_wired_linux.c | 62 +++++++++++++++++---------------
+ 1 file changed, 34 insertions(+), 28 deletions(-)
+
+diff --git a/src/drivers/driver_wired_linux.c b/src/drivers/driver_wired_linux.c
+index 245f9f9a5178..c6971a5194b0 100644
+--- a/src/drivers/driver_wired_linux.c
++++ b/src/drivers/driver_wired_linux.c
+@@ -337,11 +337,11 @@ static int driver_wired_linux_add_neigh(struct driver_wired_linux_data *drv, con
+ 
+ 	err = nl_wait_for_ack(drv->rtnl_sk);
+ 	if (err < 0) {
+-		wpa_printf(MSG_ERROR, "adding neigh " MACSTR " failed: %s",
+-			   MAC2STR(addr), nl_geterror(err));
++		wpa_printf(MSG_ERROR, "%s: adding neigh " MACSTR " failed: %s",
++			   drv->common.ifname, MAC2STR(addr), nl_geterror(err));
+ 	} else {
+-		wpa_printf(MSG_DEBUG, "added neigh: " MACSTR,
+-			   MAC2STR(addr));
++		wpa_printf(MSG_DEBUG, "%s: added neigh: " MACSTR,
++			   drv->common.ifname, MAC2STR(addr));
+ 	}
+ 
+ err_out:
+@@ -370,11 +370,11 @@ static int driver_wired_linux_del_neigh(struct driver_wired_linux_data *drv, con
+ 
+ 	err = nl_wait_for_ack(drv->rtnl_sk);
+ 	if (err < 0) {
+-		wpa_printf(MSG_ERROR, "deleting neigh " MACSTR " failed: %s",
+-			   MAC2STR(addr), nl_geterror(err));
++		wpa_printf(MSG_ERROR, "%s: deleting neigh " MACSTR " failed: %s",
++			   drv->common.ifname, MAC2STR(addr), nl_geterror(err));
+ 	} else {
+-		wpa_printf(MSG_DEBUG, "deleted neigh: " MACSTR,
+-			   MAC2STR(addr));
++		wpa_printf(MSG_DEBUG, "%s: deleted neigh: " MACSTR,
++			   drv->common.ifname, MAC2STR(addr));
+ 	}
+ 
+ err_out:
+@@ -407,9 +407,10 @@ driver_wired_linux_flush_port(struct driver_wired_linux_data *drv)
+ 
+ out:
+ 	if (err < 0)
+-		wpa_printf(MSG_ERROR, "flushing neighs failed: %s", nl_geterror(err));
++		wpa_printf(MSG_ERROR, "%s: flushing neighs failed: %s",
++			   drv->common.ifname, nl_geterror(err));
+ 	else
+-		wpa_printf(MSG_DEBUG, "flushed neighs");
++		wpa_printf(MSG_DEBUG, "%s: flushed neighs", drv->common.ifname);
+ 	nlmsg_free(msg);
+ 	return err;
+ 
+@@ -428,7 +429,7 @@ driver_wired_linux_set_port_locked(struct driver_wired_linux_data *drv,
+ 	int err;
+ 
+ 	wpa_printf(MSG_DEBUG,
+-		   "driver_linux_wired: setting port %i to %s", drv->ifindex,
++		   "%s: setting port to %s", drv->common.ifname,
+ 		   locked ? "locked" : "unlocked");
+ 
+ 	msg = nlmsg_alloc_simple(RTM_SETLINK, 0);
+@@ -459,7 +460,7 @@ driver_wired_linux_set_port_locked(struct driver_wired_linux_data *drv,
+ 
+ out:
+ 	if (err)
+-		wpa_printf(MSG_ERROR, "failed to set port: %i (%s)", err,
++		wpa_printf(MSG_ERROR, "%s: failed to set port: %i (%s)", drv->common.ifname, err,
+ 			   nl_geterror(err));
+ 	nlmsg_free(msg);
+ 	return err;
+@@ -495,7 +496,7 @@ driver_wired_linux_set_port_up(struct driver_wired_linux_data *drv, bool up)
+ 	err = 0;
+ err_out:
+ 	if (err)
+-		wpa_printf(MSG_ERROR, "failed to set port %s: %i (%s)",
++		wpa_printf(MSG_ERROR, "%s: failed to set port %s: %i (%s)", drv->common.ifname,
+ 			   up ? "up" : "down", err, nl_geterror(err));
+ 	nlmsg_free(msg);
+ 	return err;
+@@ -511,8 +512,8 @@ static void driver_wired_linux_event_rtm_newlink(void *ctx,
+ 	if (drv->ifindex > 0 && ifi->ifi_index != drv->ifindex)
+ 		return;
+ 
+-        wpa_printf(MSG_DEBUG, "RTM_NEWLINK: ifi_index=%d ifi_family=%d ifi_flags=0x%x",
+-                   ifi->ifi_index, ifi->ifi_family,
++        wpa_printf(MSG_DEBUG, "%s: RTM_NEWLINK: ifi_index=%d ifi_family=%d ifi_flags=0x%x",
++                   drv->common.ifname, ifi->ifi_index, ifi->ifi_family,
+                    ifi->ifi_flags);
+ 
+ 	running = (ifi->ifi_flags & (IFF_UP | IFF_RUNNING)) == (IFF_UP | IFF_RUNNING);
+@@ -537,8 +538,8 @@ static void driver_wired_linux_event_rtm_dellink(void *ctx,
+ 	if (ifi->ifi_index != drv->ifindex)
+ 		return;
+ 
+-        wpa_printf(MSG_DEBUG, "RTM_DELLINK: ifi_index=%d ifi_family=%d ifi_flags=0x%x",
+-                   ifi->ifi_index, ifi->ifi_family,
++        wpa_printf(MSG_DEBUG, "%s: RTM_DELLINK: ifi_index=%d ifi_family=%d ifi_flags=0x%x",
++                   drv->common.ifname, ifi->ifi_index, ifi->ifi_family,
+                    ifi->ifi_flags);
+ 
+ 	/* TODO: please do not remove the interface  */
+@@ -580,8 +581,8 @@ static void driver_wired_linux_event_rtm_newneigh(void *ctx,
+ 		attr = RTA_NEXT(attr, attrlen);
+ 	}
+ 
+-	wpa_printf(MSG_DEBUG, "Got new %slocked neigh " MACSTR,
+-		   (flags_ext & NTF_EXT_LOCKED) ? "" : "un",
++	wpa_printf(MSG_DEBUG, "%s: Got new %slocked neigh " MACSTR,
++		   drv->common.ifname, (flags_ext & NTF_EXT_LOCKED) ? "" : "un",
+ 		   MAC2STR(mac_address));
+ 
+ 	/* no need to report unlocked neighs */
+@@ -639,13 +640,13 @@ static void driver_wired_linux_event_rtm_delneigh(void *ctx,
+ 
+ 	if (sta->flags & WLAN_STA_AUTHORIZED) {
+ 		if (flags_ext & NTF_EXT_LOCKED)
+-			wpa_printf(MSG_DEBUG, "neigh " MACSTR " was locked but authorized?!",
+-				   MAC2STR(mac_address));
++			wpa_printf(MSG_DEBUG, "%s: neigh " MACSTR " was locked but authorized?!",
++				   drv->common.ifname, MAC2STR(mac_address));
+ 		ap_sta_deauthenticate(drv->common.ctx, sta, WLAN_REASON_DISASSOC_STA_HAS_LEFT);
+ 	} else {
+ 		if (!(flags_ext & NTF_EXT_LOCKED))
+-			wpa_printf(MSG_DEBUG, "neigh " MACSTR " was unlocked but not authorized?!",
+-				   MAC2STR(mac_address));
++			wpa_printf(MSG_DEBUG, "%s: neigh " MACSTR " was unlocked but not authorized?!",
++				   drv->common.ifname, MAC2STR(mac_address));
+ 		ap_sta_disassociate(drv->common.ctx, sta, WLAN_REASON_DISASSOC_STA_HAS_LEFT);
+ 	}
+ 	ap_free_sta(drv->common.ctx, sta);
+@@ -785,24 +786,29 @@ wired_linux_set_sta_authorized(void *priv, const u8 *addr,
+ 		return 0;
+ 
+ 	if (authorized) {
+-		wpa_printf(MSG_INFO, "authorizing " MACSTR, MAC2STR(addr));
++		wpa_printf(MSG_INFO, "%s: authorizing " MACSTR,
++			   drv->common.ifname, MAC2STR(addr));
+ 		if (drv->multi_auth || drv->mac_auth == ENABLE_KERNEL_MAB) {
+-			wpa_printf(MSG_DEBUG, "creating neigh");
++			wpa_printf(MSG_DEBUG, "%s: creating neigh",
++				   drv->common.ifname);
+ 			driver_wired_linux_add_neigh(priv, addr);
+ 		}
+ 
+ 		if (!drv->multi_auth && drv->locked) {
+-			wpa_printf(MSG_DEBUG, "unlocking port");
++			wpa_printf(MSG_DEBUG, "%s: unlocking port",
++				   drv->common.ifname);
+ 			driver_wired_linux_set_port_locked(drv, false);
+ 		}
+ 	} else {
+-		wpa_printf(MSG_INFO, "de-authorizing " MACSTR, MAC2STR(addr));
++		wpa_printf(MSG_INFO, "%s: de-authorizing " MACSTR,
++			   drv->common.ifname, MAC2STR(addr));
+ 		if (drv->multi_auth) {
+ 			wpa_printf(MSG_DEBUG, "removing neigh");
+ 			driver_wired_linux_del_neigh(priv, addr);
+ 		} else {
+ 			if (!drv->locked) {
+-				wpa_printf(MSG_DEBUG, "locking port");
++				wpa_printf(MSG_DEBUG, "%s: locking port",
++					   drv->common.ifname);
+ 				driver_wired_linux_set_port_locked(drv, true);
+ 				driver_wired_linux_flush_port(drv);
+ 			}
+-- 
+2.50.1
+

--- a/recipes-connectivity/hostapd/hostapd_2.10.bbappend
+++ b/recipes-connectivity/hostapd/hostapd_2.10.bbappend
@@ -10,6 +10,8 @@ SRC_URI:append = "\
     file://0007-driver_linux_wired-handle-neighs-going-away.patch \
     file://0008-driver_wired_linux-flush-all-entries-on-start-stop.patch \
     file://0009-driver_wired_linux-wait-for-bridge-attachment.patch \
+    file://0010-driver_wired_linux-unlock-neigh-before-unlocking-por.patch \
+    file://0011-driver_wired_linux-add-ifname-to-log-messages.patch \
     file://defconfig \
     file://hostapd-wired.conf \
     file://hostapd-wired@.service \


### PR DESCRIPTION
Fix two issues identified for 802.1x authentication:

* When using MAB authentication and port unlocking, the STA accounting session would be immediately stopped and the STA treated as left by hostapd, despite the port being unlocked.
* Some log messages were missing appropriate interface name prefixes, making it hard to match the log messages to the hostapd instances they belong to.