### PR TITLE
packagegroup-bisdn-linux-extra: add more text editors

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
+++ b/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
@@ -25,6 +25,14 @@ RDEPENDS:${PN} += "\
     zstd \
 "
 
+# more text editors as alternatives to vim
+RDEPENDS:${PN} += "\
+    ed \
+    joe \
+    nano \
+    mg \
+"
+
 # Workaround a bug in bitbake where runall does not properly consider all
 # transitive RDEPENDS chains, so add them explicitly.
 # Can be dropped once the fix get backported or we switch to the next LTS Yocto.


### PR DESCRIPTION
Add more text editors to give users the choice of using someting other than vim. Emacs was left out since emacs was the only one requiring a lot more than one minute to build to not increase the build time too much.

Editors added:

* ed: can't go wrong with a classic
* joe: an editor that can emulate other editors' behavior
* nano: editor with a TUI
* mg: I can't believe it's not (micro-)emacs