### PR TITLE
distro: enable minidebuginfo

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -13,7 +13,7 @@ PACKAGE_FEED_URIS ??= "${FEEDDOMAIN}/${FEEDURIPREFIX}"
 PACKAGE_FEED_BASE_PATHS ??= "ipk"
 PACKAGEFEED_ARCHS ??= "all ${TUNE_PKGARCH} ${MACHINE_ARCH}"
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci manpages usbhost vfat virtualization xattr"
+DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile minidebuginfo pci manpages usbhost vfat virtualization xattr"
 
 DISTRO_FEATURES_BACKFILL_CONSIDERED:append = " pulseaudio"
 


### PR DESCRIPTION
Enable the minidebuginfo distro feature [1] to include minimal debug elf sections in binaries just including function names.

This allows systemd-coredump and gdb to print readable stacktraces without requiring the installation of debug packages.

Slightly increases the image size by ~4% (196MB to 203MB).

[1] https://docs.yoctoproject.org/scarthgap/dev-manual/debugging.html#enabling-minidebuginfo