### PR TITLE
v5.x: distro: update FEEDURIPREFIX to point to v5.x

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -7,7 +7,7 @@ DISTRO_VERSION = "5.6.1"
 DISTRO_CODENAME = "Ortolana"
 DISTROOVERRIDES = "poky:bisdn-linux"
 
-FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/main/packages_latest-build"
+FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/v5.x/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
 PACKAGE_FEED_URIS ??= "${FEEDDOMAIN}/${FEEDURIPREFIX}"


### PR DESCRIPTION
Update the default value of FEEDURIPREFIX to point to v5.x to match v5.x now being in a separate branch.

This will also allow the ofdpa and ofdpa-binary packages to download the source packages form the correct location.