### PR TITLE
mstpd: update to 0.2.0

### DIFF
--- a/recipes-support/mstpd/mstpd_0.2.0.bb
+++ b/recipes-support/mstpd/mstpd_0.2.0.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Multiple Spanning Tree Protocol Daemon"
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4325afd396febcb659c36b49533135d4"
+
+SRC_URI = "\
+  git://github.com/bisdn/mstpd.git;branch=${PV};protocol=https \
+  file://bridge-stp.conf"
+
+PV:append = "+bisdn1"
+SRCREV = "ade1f2f1d3a73ac56a6f1def097c90c164e64321"
+
+S = "${WORKDIR}/git"
+
+inherit autotools systemd
+
+EXTRA_OECONF = "--sbindir=${base_sbindir}"
+
+# Uncomment the following lines to enable debug output in the binary.
+# Output is sent as level 4.
+# Port Information state machine:
+CFLAGS += " -DPISM_ENABLE_LOG"
+# Port Role Transitions state machine:
+CFLAGS += " -DPRTSM_ENABLE_LOG"
+#
+# Packets (printf, always active):
+CFLAGS += " -DPACKET_DEBUG"
+
+FILES:${PN} += "${systemd_system_unitdir}/mstpd.service"
+
+SYSTEMD_SERVICE:${PN} = "mstpd.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"
+
+do_install:append() {
+   # we do not use it nor can we use it, and shipping it will add a unnecessary
+   # depdency on python (2)
+   rm ${D}${libexecdir}/mstpctl-utils/ifquery
+
+   install -d ${D}${systemd_unitdir}/system
+   install -m 0644 ${WORKDIR}/build/utils/mstpd.service ${D}${systemd_unitdir}/system
+
+   install -m 0644 ${WORKDIR}/bridge-stp.conf ${D}${sysconfdir}/bridge-stp.conf
+}


### PR DESCRIPTION
Update mstpd to 0.2.0:

    8995e5d11ee8 release: prepare release for 0.2.0 version
    ef0add3d78f4 TCSM: fix infinite recursion for MSTI per-tree ports
    d0e609278779 packet: set socket priority to TC_PRIO_CONTROL
    d50b02c4f807 README.md: clarify IVL/SVL and MSTI support in linux
    7642f48ed565 README.md: update FID/MSTI limits
    d48a881d8b65 README.md: add packaging status
    2f57bd5b7fb3 mstp: increase maxHops limit to 100
    3b7d805c01de mstp: do not overflow calculated root path costs
    e894644b7371 mstp: do not allow changing Bridge Hello Time
    c42aa3708dd0 mstp: validate admin port path costs
    1b7fbe20dfc3 ctl_socket_server: require root for changing configuration
    e4c103ffb859 README.md: update IRC channel location