### PR TITLE
bash rc improvements

### DIFF
--- a/recipes-core/base-files/base-files/bisdn-linux/share/dot.bashrc
+++ b/recipes-core/base-files/base-files/bisdn-linux/share/dot.bashrc
@@ -1,0 +1,16 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+
+export PS1='\h:\w\$ '
+umask 022
+
+# You may uncomment the following lines if you want `ls' to be colorized:
+# export LS_OPTIONS='--color=auto'
+# eval `dircolors`
+# alias ls='ls $LS_OPTIONS'
+# alias ll='ls $LS_OPTIONS -l'
+# alias l='ls $LS_OPTIONS -lA'
+#
+# Some more alias to avoid making mistakes:
+# alias rm='rm -i'
+# alias cp='cp -i'
+# alias mv='mv -i'

--- a/recipes-core/base-files/base-files/bisdn-linux/share/dot.bashrc
+++ b/recipes-core/base-files/base-files/bisdn-linux/share/dot.bashrc
@@ -3,6 +3,9 @@
 export PS1='\h:\w\$ '
 umask 022
 
+# allow autocomplete with sudo
+complete -cf sudo
+
 # enable automatic color support where supported
 alias ls='ls --color=auto'
 alias ip='ip --color=auto'

--- a/recipes-core/base-files/base-files/bisdn-linux/share/dot.bashrc
+++ b/recipes-core/base-files/base-files/bisdn-linux/share/dot.bashrc
@@ -3,13 +3,12 @@
 export PS1='\h:\w\$ '
 umask 022
 
-# You may uncomment the following lines if you want `ls' to be colorized:
-# export LS_OPTIONS='--color=auto'
-# eval `dircolors`
-# alias ls='ls $LS_OPTIONS'
-# alias ll='ls $LS_OPTIONS -l'
-# alias l='ls $LS_OPTIONS -lA'
-#
+# enable automatic color support where supported
+alias ls='ls --color=auto'
+alias ip='ip --color=auto'
+alias bridge='bridge --color=auto'
+alias git='git --color=auto'
+
 # Some more alias to avoid making mistakes:
 # alias rm='rm -i'
 # alias cp='cp -i'


### PR DESCRIPTION
Out shell is currently very grey, but many utilities support colors. So let's enable colors for ls, ip and bridge.

Also, when trying to sudo something, tab autocompletion does not work for that. Add an appropriate complete call so it does.