### PR TITLE
update kernel networking utilities

### DIFF
--- a/recipes-connectivity/iproute2/iproute2/0001-include-libnetlink.h-add-missing-include-for-htobe64.patch
+++ b/recipes-connectivity/iproute2/iproute2/0001-include-libnetlink.h-add-missing-include-for-htobe64.patch
@@ -1,0 +1,24 @@
+From 4dc0613e229f6b4a57beb00dde14ef319a2dcad8 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex@linutronix.de>
+Date: Sat, 24 Aug 2024 15:32:25 +0200
+Subject: [PATCH] include/libnetlink.h: add missing include for htobe64
+ definitions
+
+Upstream-Status: Submitted [by email to stephen@networkplumber.org netdev@vger.kernel.org]
+Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+---
+ include/libnetlink.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/libnetlink.h b/include/libnetlink.h
+index 30f0c2d..77e8181 100644
+--- a/include/libnetlink.h
++++ b/include/libnetlink.h
+@@ -12,6 +12,7 @@
+ #include <linux/neighbour.h>
+ #include <linux/netconf.h>
+ #include <arpa/inet.h>
++#include <endian.h>
+ 
+ struct rtnl_handle {
+ 	int			fd;

--- a/recipes-connectivity/iproute2/iproute2/0001-ip-rearrange-and-prune-header-files.patch
+++ b/recipes-connectivity/iproute2/iproute2/0001-ip-rearrange-and-prune-header-files.patch
@@ -1,0 +1,90 @@
+From 714291a63246cb3e6b86eb2a78fa84216d768a4b Mon Sep 17 00:00:00 2001
+From: Stephen Hemminger <stephen@networkplumber.org>
+Date: Tue, 10 Dec 2024 13:38:08 -0800
+Subject: [PATCH] ip: rearrange and prune header files
+
+The recent report of issues with missing limits.h impacting musl
+suggested looking at what files are and are not included in ip code.
+
+The standard practice is to put standard headers first, then system,
+then local headers. Used iwyu to get suggestions about missing
+and extraneous headers.
+
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=7e23da91fca6e5dedeb32a7d308cf20982e897c3]
+Signed-off-by: Stephen Hemminger <stephen@networkplumber.org>
+Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+---
+ ip/iplink.c  | 13 +++++--------
+ ip/ipnetns.c | 19 +++++++++----------
+ 2 files changed, 14 insertions(+), 18 deletions(-)
+
+diff --git a/ip/iplink.c b/ip/iplink.c
+index e650a5c2..8df367ed 100644
+--- a/ip/iplink.c
++++ b/ip/iplink.c
+@@ -11,17 +11,14 @@
+ #include <fcntl.h>
+ #include <dlfcn.h>
+ #include <errno.h>
++#include <string.h>
++#include <strings.h>
++#include <limits.h>
++
+ #include <sys/socket.h>
++#include <arpa/inet.h>
+ #include <linux/if.h>
+-#include <linux/if_packet.h>
+ #include <linux/if_ether.h>
+-#include <linux/sockios.h>
+-#include <netinet/in.h>
+-#include <arpa/inet.h>
+-#include <string.h>
+-#include <sys/ioctl.h>
+-#include <stdbool.h>
+-#include <linux/mpls.h>
+ 
+ #include "rt_names.h"
+ #include "utils.h"
+diff --git a/ip/ipnetns.c b/ip/ipnetns.c
+index 5c943400..a20cd8bc 100644
+--- a/ip/ipnetns.c
++++ b/ip/ipnetns.c
+@@ -1,21 +1,21 @@
+ /* SPDX-License-Identifier: GPL-2.0 */
+ #define _ATFILE_SOURCE
+-#include <sys/file.h>
+-#include <sys/types.h>
+-#include <sys/stat.h>
+-#include <sys/wait.h>
+-#include <sys/inotify.h>
+-#include <sys/mount.h>
+-#include <sys/syscall.h>
++
+ #include <stdio.h>
++#include <stdint.h>
+ #include <string.h>
+-#include <sched.h>
+ #include <fcntl.h>
+ #include <dirent.h>
+ #include <errno.h>
+ #include <unistd.h>
+ #include <ctype.h>
+-#include <linux/limits.h>
++#include <limits.h>
++
++#include <sys/file.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <sys/inotify.h>
++#include <sys/mount.h>
+ 
+ #include <linux/net_namespace.h>
+ 
+@@ -23,7 +23,6 @@
+ #include "list.h"
+ #include "ip_common.h"
+ #include "namespace.h"
+-#include "json_print.h"
+ 
+ static int usage(void)
+ {

--- a/recipes-connectivity/iproute2/iproute2_6.12.0.bb
+++ b/recipes-connectivity/iproute2/iproute2_6.12.0.bb
@@ -11,9 +11,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=eb723b61539feef013de476e68b5c50a \
 
 DEPENDS = "flex-native bison-native iptables libcap"
 
-SRC_URI = "${KERNELORG_MIRROR}/linux/utils/net/${BPN}/${BP}.tar.xz"
+SRC_URI = "${KERNELORG_MIRROR}/linux/utils/net/${BPN}/${BP}.tar.xz \
+           file://0001-include-libnetlink.h-add-missing-include-for-htobe64.patch \
+           file://0001-ip-rearrange-and-prune-header-files.patch \
+           "
 
-SRC_URI[sha256sum] = "ff942dd9828d7d1f867f61fe72ce433078c31e5d8e4a78e20f02cb5892e8841d"
+SRC_URI[sha256sum] = "bbd141ef7b5d0127cc2152843ba61f274dc32814fa3e0f13e7d07a080bef53d9"
 
 inherit update-alternatives bash-completion pkgconfig
 
@@ -53,12 +56,16 @@ do_install () {
     install -d ${D}${datadir}
     mv ${D}/share/* ${D}${datadir}/ || true
     rm ${D}/share -rf || true
+
+    # Remove support fot ipt and xt in tc. So tc library directory is not needed.
+    rm ${D}${libdir}/tc -rf
 }
 
 # The .so files in iproute2-tc are modules, not traditional libraries
 INSANE_SKIP:${PN}-tc = "dev-so"
 
 IPROUTE2_PACKAGES =+ "\
+    ${PN}-bridge \
     ${PN}-devlink \
     ${PN}-genl \
     ${PN}-ifstat \
@@ -91,6 +98,7 @@ FILES:${PN}-tipc = "${base_sbindir}/tipc"
 FILES:${PN}-devlink = "${base_sbindir}/devlink"
 FILES:${PN}-rdma = "${base_sbindir}/rdma"
 FILES:${PN}-routel = "${base_sbindir}/routel"
+FILES:${PN}-bridge = "${base_sbindir}/bridge"
 
 RDEPENDS:${PN}-routel = "python3-core"
 

--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -19,6 +19,7 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     grpc-cli \
     hostapd \
     ipcalc \
+    iproute2-bridge \
     iproute2-ss \
     iptables \
     jq \

--- a/recipes-extended/ethtool/ethtool/avoid_parallel_tests.patch
+++ b/recipes-extended/ethtool/ethtool/avoid_parallel_tests.patch
@@ -1,0 +1,28 @@
+From 63f7fd18fe8ede3bde7fa54ef22980b4815330ed Mon Sep 17 00:00:00 2001
+From: Tudor Florea <tudor.florea@enea.com>
+Date: Wed, 28 May 2014 18:59:54 +0200
+Subject: [PATCH] ethtool: use serial-tests config needed by ptest.
+
+ptest needs buildtest-TESTS and runtest-TESTS targets.
+serial-tests is required to generate those targets.
+
+Signed-off-by: Tudor Florea <tudor.florea@enea.com>
+Upstream-Status: Inappropriate
+(default automake behavior incompatible with ptest)
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index ebb978f..57b624b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3,7 +3,7 @@ AC_INIT(ethtool, 6.19, netdev@vger.kernel.org)
+ AC_PREREQ(2.52)
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_CONFIG_SRCDIR([ethtool.c])
+-AM_INIT_AUTOMAKE([gnu subdir-objects])
++AM_INIT_AUTOMAKE([gnu subdir-objects serial-tests])
+ AC_CONFIG_HEADERS([ethtool-config.h])
+ 
+ AM_MAINTAINER_MODE

--- a/recipes-extended/ethtool/ethtool/run-ptest
+++ b/recipes-extended/ethtool/ethtool/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+make -k runtest-TESTS

--- a/recipes-extended/ethtool/ethtool_6.19.bb
+++ b/recipes-extended/ethtool/ethtool_6.19.bb
@@ -1,0 +1,39 @@
+SUMMARY = "Display or change ethernet card settings"
+DESCRIPTION = "A small utility for examining and tuning the settings of your ethernet-based network interfaces."
+HOMEPAGE = "http://www.kernel.org/pub/software/network/ethtool/"
+SECTION = "console/network"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://ethtool.c;beginline=4;endline=17;md5=c19b30548c582577fc6b443626fc1216"
+
+SRC_URI = "${KERNELORG_MIRROR}/software/network/ethtool/ethtool-${PV}.tar.gz \
+           file://run-ptest \
+           file://avoid_parallel_tests.patch \
+           "
+
+SRC_URI[sha256sum] = "1c1a2f9fc02670ab005fb3e5de16688852bd6cea7e15ebc6ec91d0278b00dd79"
+
+UPSTREAM_CHECK_URI = "https://www.kernel.org/pub/software/network/ethtool/"
+
+inherit autotools ptest bash-completion pkgconfig
+
+RDEPENDS:${PN}-ptest += "make bash"
+
+PACKAGECONFIG ?= "netlink"
+PACKAGECONFIG[netlink] = "--enable-netlink,--disable-netlink,libmnl,"
+
+FILES:${PN} += "${datadir}/metainfo/org.kernel.software.network.ethtool.metainfo.xml"
+
+do_compile_ptest() {
+   oe_runmake buildtest-TESTS
+}
+
+do_install_ptest () {
+   cp ${B}/Makefile                 ${D}${PTEST_PATH}
+   install ${B}/test-cmdline        ${D}${PTEST_PATH}
+   if ${@bb.utils.contains('PACKAGECONFIG', 'netlink', 'false', 'true', d)}; then
+       install ${B}/test-features       ${D}${PTEST_PATH}
+   fi
+   install ${B}/ethtool             ${D}${PTEST_PATH}/ethtool
+   sed -i 's/^Makefile/_Makefile/'  ${D}${PTEST_PATH}/Makefile
+}


### PR DESCRIPTION
Update kernel networking utilities to newer versions:

* iproute2 to 6.12, matching our kernel version.
* ethtool to latest, to have the newest SFP eeprom matching code