### PR TITLE
allow passing configuration to the installer

### DIFF
--- a/recipes-core/images/onie-nos-installer.inc
+++ b/recipes-core/images/onie-nos-installer.inc
@@ -50,6 +50,9 @@ do_onie_bundle () {
         --numeric-owner --owner=0 --group=0 --mtime="@${SOURCE_DATE_EPOCH}" \
         -C "${ONIEIMAGE_DIR}" -cf "${ONIEIMAGE_PAYLOAD_FILE}" "installer"
 
+    # append config marker
+    echo -e "\nconf_marker" >> "${ONIEIMAGE_PAYLOAD_FILE}"
+
     # Populate the shell archive body
     cp "${ONIEIMAGE_SHELL_ARCHIVE_BODY}" "${ONIEIMAGE_OUTPUT_FILE}"
     image_sha1=$(sha1sum "${ONIEIMAGE_PAYLOAD_FILE}" | awk '{print $1}')

--- a/recipes-core/images/onie-nos-installer.inc
+++ b/recipes-core/images/onie-nos-installer.inc
@@ -48,6 +48,9 @@ do_onie_bundle () {
         --numeric-owner --owner=0 --group=0 --mtime="@${SOURCE_DATE_EPOCH}" \
         -C "${ONIEIMAGE_DIR}" -cf "${ONIEIMAGE_PAYLOAD_FILE}" "installer"
 
+    # append config marker
+    echo -e "\nconf_marker" >> "${ONIEIMAGE_PAYLOAD_FILE}"
+
     # Populate the shell archive body
     cp "${ONIEIMAGE_SHELL_ARCHIVE_BODY}" "${ONIEIMAGE_OUTPUT_FILE}"
     image_sha1=$(sha1sum "${ONIEIMAGE_PAYLOAD_FILE}" | awk '{print $1}')

--- a/scripts/installer/install.conf.template
+++ b/scripts/installer/install.conf.template
@@ -20,3 +20,11 @@
 # Set a default password hash for the baseboxd user. This can be generated e.g.
 # via mkpasswd or openssl passwd.
 # DEFAULT_PASSWORD="$6$2zTHd7.l2MZBTq5j$LAwBkh6ILoFcqQyKhwzWe/jm.y/R3Mv0tsOhEbssq.ZLNiXivGpQUmKUWJSvoncQMj/jboLCQAH689wRfUy18."
+
+# Prepopulate /etc/basebox/.ssh/authorized_keys with the supplied content.
+# Multiple lines can be set using \ at the end, e.g.
+# AUTHORIZED_SSH_KEYS="key1 \
+# key2 \
+# key3"
+#
+# AUTHORIZED_SSH_KEYS=""

--- a/scripts/installer/install.conf.template
+++ b/scripts/installer/install.conf.template
@@ -6,6 +6,12 @@
 # out, then ppending this file to the installer via
 #   cat install.conf.template >> onie-bisdn-linux(...).bin
 
+# Control whether to keep configuration when installing with an existing BISDN
+# Linux installation present:
+#   "true"            take over configiration from previous installation
+#   "false"           reset to defaults
+# KEEP_CONFIG="true"
+
 # Set a default network configuration for the front ports:
 #   "none"             all front ports down, no configuration
 #   "simple-l2-bridge" all front ports up, bridged

--- a/scripts/installer/install.conf.template
+++ b/scripts/installer/install.conf.template
@@ -1,0 +1,7 @@
+# install-config 1.0
+#
+# BISDN Linux Installation configuration
+#
+# Customize the installation by uncommenting desired options and filling them
+# out, then ppending this file to the installer via
+#   cat install.conf.template >> onie-bisdn-linux(...).bin

--- a/scripts/installer/install.conf.template
+++ b/scripts/installer/install.conf.template
@@ -5,3 +5,8 @@
 # Customize the installation by uncommenting desired options and filling them
 # out, then ppending this file to the installer via
 #   cat install.conf.template >> onie-bisdn-linux(...).bin
+
+# Set a default network configuration for the front ports:
+#   "none"             all front ports down, no configuration
+#   "simple-l2-bridge" all front ports up, bridged
+# DEFAULT_CONFIG="none"

--- a/scripts/installer/install.conf.template
+++ b/scripts/installer/install.conf.template
@@ -16,3 +16,7 @@
 #   "none"             all front ports down, no configuration
 #   "simple-l2-bridge" all front ports up, bridged
 # DEFAULT_CONFIG="none"
+
+# Set a default password hash for the baseboxd user. This can be generated e.g.
+# via mkpasswd or openssl passwd.
+# DEFAULT_PASSWORD="$6$2zTHd7.l2MZBTq5j$LAwBkh6ILoFcqQyKhwzWe/jm.y/R3Mv0tsOhEbssq.ZLNiXivGpQUmKUWJSvoncQMj/jboLCQAH689wRfUy18."

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -250,7 +250,20 @@ create_bisdn_linux_msdos_partition()
     echo "$part"
 }
 
+get_boolean()
+{
+    case "$1" in
+        y|Y|yes|true)
+            echo "true"
+            ;;
+        *)
+            echo "false"
+            ;;
+    esac
+}
+
 DEFAULT_CONFIG=
+KEEP_CONFIG=true
 
 # parse a config file with FOO=bar assignments
 # supports comments (prefixed with #) and continuation via \
@@ -331,6 +344,9 @@ ${line%\"}"
             DEFAULT_CONFIG)
                 DEFAULT_CONFIG=$value
                 ;;
+            KEEP_CONFIG)
+                KEEP_CONFIG=$(get_boolean $value)
+                ;;
             *)
                 echo "WARNING: unknown configuration item '$var'" >&2
                 ;;
@@ -345,6 +361,7 @@ print_config()
 {
     echo "#####################################################################"
     echo "Installing with the following configuration:                         "
+    echo "  Keep existing configuration:          ${KEEP_CONFIG}               "
     echo "  Default network configuration:        ${DEFAULT_CONFIG:-none}      "
     echo "#####################################################################"
 }
@@ -467,6 +484,7 @@ fi
 
 if [ -n "$BISDN_DEFAULT_CONFIG" ]; then
     DEFAULT_CONFIG=$BISDN_DEFAULT_CONFIG
+    KEEP_CONFIG=false
 fi
 
 print_config
@@ -476,7 +494,7 @@ old_part=$(eval $detect_bisdn_linux_partition $boot_dev)
 if [ -n "$old_part" ]; then
     # old_part contains partition number of existing BISDN Linux installation
 
-    if [ -z "$DEFAULT_CONFIG" ]; then
+    if [ "$KEEP_CONFIG" = true ]; then
         # backup existing config
         backup_cfg $boot_dev $old_part
     fi
@@ -585,16 +603,16 @@ platform_setup
 # Restore the network configuration from previous installation
 if [ "${DO_RESTORE}" = true ]; then
     restore_cfg $backup_tmp_dir $bisdn_linux_mnt
-fi;
-
-if [ -n "$DEFAULT_CONFIG" ] && [ "$DEFAULT_CONFIG" != "none" ]; then
-    example_path="/usr/share/baseboxd/default_configurations/$DEFAULT_CONFIG"
-    if [ -d "${bisdn_linux_mnt}${example_path}" ]; then
-        # copy *.netdev and *.network files, but not e.g. *.md
-        cp "${bisdn_linux_mnt}${example_path}/"*.net* \
-            "${bisdn_linux_mnt}/${SYSTEMD_NETWORK_CONFDIR}"
-    else
-        echo "WARNING: no default config '$DEFAULT_CONFIG' found."
+else
+    if [ -n "$DEFAULT_CONFIG" ] && [ "$DEFAULT_CONFIG" != "none" ]; then
+        example_path="/usr/share/baseboxd/default_configurations/$DEFAULT_CONFIG"
+        if [ -d "${bisdn_linux_mnt}${example_path}" ]; then
+            # copy *.netdev and *.network files, but not e.g. *.md
+            cp "${bisdn_linux_mnt}${example_path}/"*.net* \
+                "${bisdn_linux_mnt}/${SYSTEMD_NETWORK_CONFDIR}"
+        else
+            echo "WARNING: no default config '$DEFAULT_CONFIG' found."
+        fi
     fi
 fi
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -263,6 +263,7 @@ get_boolean()
 }
 
 DEFAULT_CONFIG=
+DEFAULT_PASSWORD=
 KEEP_CONFIG=true
 
 # parse a config file with FOO=bar assignments
@@ -344,6 +345,9 @@ ${line%\"}"
             DEFAULT_CONFIG)
                 DEFAULT_CONFIG=$value
                 ;;
+            DEFAULT_PASSWORD)
+                DEFAULT_PASSWORD=$value
+                ;;
             KEEP_CONFIG)
                 KEEP_CONFIG=$(get_boolean $value)
                 ;;
@@ -363,6 +367,12 @@ print_config()
     echo "Installing with the following configuration:                         "
     echo "  Keep existing configuration:          ${KEEP_CONFIG}               "
     echo "  Default network configuration:        ${DEFAULT_CONFIG:-none}      "
+    echo -n "  Default password:                     "
+    if [ -n  "$DEFAULT_PASSWORD" ]; then
+        echo "<custom>"
+    else
+        echo "<default>"
+    fi
     echo "#####################################################################"
 }
 
@@ -613,6 +623,11 @@ else
         else
             echo "WARNING: no default config '$DEFAULT_CONFIG' found."
         fi
+    fi
+
+    if [ -n "$DEFAULT_PASSWORD" ]; then
+        # replace password with new hash
+        sed -i "s/basebox:[^:]*/basebox:$DEFAULT_PASSWORD/" "${bisdn_linux_mnt}/etc/shadow"
     fi
 fi
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -262,6 +262,7 @@ get_boolean()
     esac
 }
 
+AUTHORIZED_SSH_KEYS=
 DEFAULT_CONFIG=
 DEFAULT_PASSWORD=
 KEEP_CONFIG=true
@@ -342,6 +343,9 @@ ${line%\"}"
         esac
 
         case "$var" in
+            AUTHORIZED_SSH_KEYS)
+                AUTHORIZED_SSH_KEYS=$value
+                ;;
             DEFAULT_CONFIG)
                 DEFAULT_CONFIG=$value
                 ;;
@@ -372,6 +376,12 @@ print_config()
         echo "<custom>"
     else
         echo "<default>"
+    fi
+    echo -n "  Authorized SSH keys:                  "
+    if [ -n  "$DEFAULT_PASSWORD" ]; then
+        echo "present"
+    else
+        echo "none"
     fi
     echo "#####################################################################"
 }
@@ -628,6 +638,14 @@ else
     if [ -n "$DEFAULT_PASSWORD" ]; then
         # replace password with new hash
         sed -i "s/basebox:[^:]*/basebox:$DEFAULT_PASSWORD/" "${bisdn_linux_mnt}/etc/shadow"
+    fi
+    if [ -n "$AUTHORIZED_SSH_KEYS" ]; then
+        mkdir -p "${bisdn_linux_mnt}/home/basebox/.ssh/"
+        echo "$AUTHORIZED_SSH_KEYS" > "${bisdn_linux_mnt}/home/basebox/.ssh/authorized_keys"
+
+        chmod 0755 "${bisdn_linux_mnt}/home/basebox/.ssh/authorized_keys"
+        chmod 0700 "${bisdn_linux_mnt}/home/basebox/.ssh/"
+        chown -R 1000:1000 "${bisdn_linux_mnt}/home/basebox/.ssh/"
     fi
 fi
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -250,6 +250,8 @@ create_bisdn_linux_msdos_partition()
     echo "$part"
 }
 
+DEFAULT_CONFIG=
+
 # parse a config file with FOO=bar assignments
 # supports comments (prefixed with #) and continuation via \
 # at the end.
@@ -326,6 +328,9 @@ ${line%\"}"
         esac
 
         case "$var" in
+            DEFAULT_CONFIG)
+                DEFAULT_CONFIG=$value
+                ;;
             *)
                 echo "WARNING: unknown configuration item '$var'" >&2
                 ;;
@@ -340,6 +345,7 @@ print_config()
 {
     echo "#####################################################################"
     echo "Installing with the following configuration:                         "
+    echo "  Default network configuration:        ${DEFAULT_CONFIG:-none}      "
     echo "#####################################################################"
 }
 
@@ -459,6 +465,10 @@ if [ -f ./install.conf ]; then
     parse_config ./install.conf
 fi
 
+if [ -n "$BISDN_DEFAULT_CONFIG" ]; then
+    DEFAULT_CONFIG=$BISDN_DEFAULT_CONFIG
+fi
+
 print_config
 
 # See if BISDN Linux partition already exists
@@ -466,7 +476,7 @@ old_part=$(eval $detect_bisdn_linux_partition $boot_dev)
 if [ -n "$old_part" ]; then
     # old_part contains partition number of existing BISDN Linux installation
 
-    if [ -z "$BISDN_DEFAULT_CONFIG" ]; then
+    if [ -z "$DEFAULT_CONFIG" ]; then
         # backup existing config
         backup_cfg $boot_dev $old_part
     fi
@@ -577,14 +587,14 @@ if [ "${DO_RESTORE}" = true ]; then
     restore_cfg $backup_tmp_dir $bisdn_linux_mnt
 fi;
 
-if [ -n "$BISDN_DEFAULT_CONFIG" ] && [ "$BISDN_DEFAULT_CONFIG" != "none" ]; then
-    example_path="/usr/share/baseboxd/default_configurations/$BISDN_DEFAULT_CONFIG"
+if [ -n "$DEFAULT_CONFIG" ] && [ "$DEFAULT_CONFIG" != "none" ]; then
+    example_path="/usr/share/baseboxd/default_configurations/$DEFAULT_CONFIG"
     if [ -d "${bisdn_linux_mnt}${example_path}" ]; then
         # copy *.netdev and *.network files, but not e.g. *.md
         cp "${bisdn_linux_mnt}${example_path}/"*.net* \
             "${bisdn_linux_mnt}/${SYSTEMD_NETWORK_CONFDIR}"
     else
-        echo "WARNING: no default config '$BISDN_DEFAULT_CONFIG' found."
+        echo "WARNING: no default config '$DEFAULT_CONFIG' found."
     fi
 fi
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -250,6 +250,99 @@ create_bisdn_linux_msdos_partition()
     echo "$part"
 }
 
+# parse a config file with FOO=bar assignments
+# supports comments (prefixed with #) and continuation via \
+# at the end.
+# Strips enclosing quotes from values.
+parse_config()
+{
+    local config="$1"
+    local var value
+
+    while read -r line; do
+        # strip carriage-return in case of windows format
+        line=${line//$'\r'/}
+
+        case "$line" in
+            \#*)
+                # skip comments
+                continue
+                ;;
+            *\\)
+                if [ -n "$var" ]; then
+                    # continuation of previous multi-line assignment
+                    # strip trailing slash and append
+                    line=${line%\\}
+                    value="${value}
+${line}"
+                else
+                    # beginning of multi-line assignment
+
+                    # split by first = and strip surrounding whitespace
+                    var=$(echo ${line%=*})
+                    value=$(echo ${line#*=})
+
+                    # strip opening quote if present
+                    value=${value#\"}
+                    # strip trailing slash
+                    value=${value%\\}
+                fi
+                continue
+                ;;
+            *=*)
+                if [ -n "$var" ]; then
+                    # end of previous multi-line assignment
+                    # strip closing quote if present and append
+                    line=${line%\"}
+                    value="${value}
+${line}"
+                else
+                    # single-line assignment
+
+                    # split by first = and strip surrounding whitespace
+                    var=$(echo ${line%=*})
+                    value=$(echo ${line#*=})
+
+                    # strip opening quote if present
+                    value=${value#\"}
+                    # strip closing quotes if present
+                    value=${value%\"}
+                fi
+                ;;
+            *)
+                if [ -z "$value" ]; then
+                    if [ -n "$line" ]; then
+                        echo "WARNING: unexpected line '$line'" >&2
+                    fi
+                    continue
+                fi
+
+                # end of previous multi-line assignment
+                # strip closing quote if present and append
+                line=${line%\"}
+                value="${value}
+${line%\"}"
+                ;;
+        esac
+
+        case "$var" in
+            *)
+                echo "WARNING: unknown configuration item '$var'" >&2
+                ;;
+        esac
+
+        var=
+        value=
+    done < $config
+}
+
+print_config()
+{
+    echo "#####################################################################"
+    echo "Installing with the following configuration:                         "
+    echo "#####################################################################"
+}
+
 # default platform functions
 
 platform_check()
@@ -361,6 +454,12 @@ fi
 
 # do only restore if backup has been created
 DO_RESTORE=false
+
+if [ -f ./install.conf ]; then
+    parse_config ./install.conf
+fi
+
+print_config
 
 # See if BISDN Linux partition already exists
 old_part=$(eval $detect_bisdn_linux_partition $boot_dev)

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -263,6 +263,7 @@ get_boolean()
 }
 
 DEFAULT_CONFIG=
+DEFAULT_PASSWORD=
 KEEP_CONFIG=true
 
 # parse a config file with FOO=bar assignments
@@ -358,6 +359,9 @@ ${line%\"}"
             DEFAULT_CONFIG)
                 DEFAULT_CONFIG=$value
                 ;;
+            DEFAULT_PASSWORD)
+                DEFAULT_PASSWORD=$value
+                ;;
             KEEP_CONFIG)
                 KEEP_CONFIG=$(get_boolean $value)
                 ;;
@@ -377,6 +381,12 @@ print_config()
     echo "Installing with the following configuration:                         "
     echo "  Keep existing configuration:          ${KEEP_CONFIG}               "
     echo "  Default network configuration:        ${DEFAULT_CONFIG:-none}      "
+    echo -n "  Default password:                     "
+    if [ -n  "$DEFAULT_PASSWORD" ]; then
+        echo "<custom>"
+    else
+        echo "<default>"
+    fi
     echo "#####################################################################"
 }
 
@@ -627,6 +637,11 @@ else
         else
             echo "WARNING: no default config '$DEFAULT_CONFIG' found."
         fi
+    fi
+
+    if [ -n "$DEFAULT_PASSWORD" ]; then
+        # replace password with new hash
+        sed -i "s|basebox:[^:]*|basebox:$DEFAULT_PASSWORD|" "${bisdn_linux_mnt}/etc/shadow"
     fi
 fi
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -250,6 +250,113 @@ create_bisdn_linux_msdos_partition()
     echo "$part"
 }
 
+# parse a config file with FOO=bar assignments
+# supports comments (prefixed with #) and continuation via \
+# at the end.
+# Strips enclosing quotes from values.
+parse_config()
+{
+    local config="$1"
+    local var value line
+
+    line=$(head -n 1 $config)
+    # strip carriage-return in case of windows format
+    line=${line//$'\r'/}
+
+    # check the format, in case we need to switch to a newer one in the future
+    case "$line" in
+        "# install-config 1.0")
+	    ;;
+        *)
+            echo "ERROR: install config found, but format unsupported ('$line')" >&2
+	    return 1
+	    ;;
+    esac
+
+    while read -r line; do
+        # strip carriage-return in case of windows format
+        line=${line//$'\r'/}
+
+        case "$line" in
+            \#*)
+                # skip comments
+                continue
+                ;;
+            *\\)
+                if [ -n "$var" ]; then
+                    # continuation of previous multi-line assignment
+                    # strip trailing slash and append
+                    line=${line%\\}
+                    value="${value}
+${line}"
+                else
+                    # beginning of multi-line assignment
+
+                    # split by first = and strip surrounding whitespace
+                    var=$(echo ${line%=*})
+                    value=$(echo ${line#*=})
+
+                    # strip opening quote if present
+                    value=${value#\"}
+                    # strip trailing slash
+                    value=${value%\\}
+                fi
+                continue
+                ;;
+            *=*)
+                if [ -n "$var" ]; then
+                    # end of previous multi-line assignment
+                    # strip closing quote if present and append
+                    line=${line%\"}
+                    value="${value}
+${line}"
+                else
+                    # single-line assignment
+
+                    # split by first = and strip surrounding whitespace
+                    var=$(echo ${line%=*})
+                    value=$(echo ${line#*=})
+
+                    # strip opening quote if present
+                    value=${value#\"}
+                    # strip closing quotes if present
+                    value=${value%\"}
+                fi
+                ;;
+            *)
+                if [ -z "$value" ]; then
+                    if [ -n "$line" ]; then
+                        echo "WARNING: unexpected line '$line'" >&2
+                    fi
+                    continue
+                fi
+
+                # end of previous multi-line assignment
+                # strip closing quote if present and append
+                line=${line%\"}
+                value="${value}
+${line%\"}"
+                ;;
+        esac
+
+        case "$var" in
+            *)
+                echo "WARNING: unknown configuration item '$var'" >&2
+                ;;
+        esac
+
+        var=
+        value=
+    done < $config
+}
+
+print_config()
+{
+    echo "#####################################################################"
+    echo "Installing with the following configuration:                         "
+    echo "#####################################################################"
+}
+
 # default platform functions
 
 platform_check()
@@ -361,6 +468,12 @@ fi
 
 # do only restore if backup has been created
 DO_RESTORE=false
+
+if [ -f ./install.conf ]; then
+    parse_config ./install.conf
+fi
+
+print_config
 
 # See if BISDN Linux partition already exists
 old_part=$(eval $detect_bisdn_linux_partition $boot_dev)

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -262,6 +262,7 @@ get_boolean()
     esac
 }
 
+AUTHORIZED_SSH_KEYS=
 DEFAULT_CONFIG=
 DEFAULT_PASSWORD=
 KEEP_CONFIG=true
@@ -356,6 +357,9 @@ ${line%\"}"
         esac
 
         case "$var" in
+            AUTHORIZED_SSH_KEYS)
+                AUTHORIZED_SSH_KEYS=$value
+                ;;
             DEFAULT_CONFIG)
                 DEFAULT_CONFIG=$value
                 ;;
@@ -386,6 +390,12 @@ print_config()
         echo "<custom>"
     else
         echo "<default>"
+    fi
+    echo -n "  Authorized SSH keys:                  "
+    if [ -n  "$AUTHORIZED_SSH_KEYS" ]; then
+        echo "present"
+    else
+        echo "none"
     fi
     echo "#####################################################################"
 }
@@ -642,6 +652,14 @@ else
     if [ -n "$DEFAULT_PASSWORD" ]; then
         # replace password with new hash
         sed -i "s|basebox:[^:]*|basebox:$DEFAULT_PASSWORD|" "${bisdn_linux_mnt}/etc/shadow"
+    fi
+    if [ -n "$AUTHORIZED_SSH_KEYS" ]; then
+        mkdir -p "${bisdn_linux_mnt}/home/basebox/.ssh/"
+        echo "$AUTHORIZED_SSH_KEYS" > "${bisdn_linux_mnt}/home/basebox/.ssh/authorized_keys"
+
+        chmod 0755 "${bisdn_linux_mnt}/home/basebox/.ssh/authorized_keys"
+        chmod 0700 "${bisdn_linux_mnt}/home/basebox/.ssh/"
+        chown -R 1000:1000 "${bisdn_linux_mnt}/home/basebox/.ssh/"
     fi
 fi
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -250,6 +250,8 @@ create_bisdn_linux_msdos_partition()
     echo "$part"
 }
 
+DEFAULT_CONFIG=
+
 # parse a config file with FOO=bar assignments
 # supports comments (prefixed with #) and continuation via \
 # at the end.
@@ -340,6 +342,9 @@ ${line%\"}"
         esac
 
         case "$var" in
+            DEFAULT_CONFIG)
+                DEFAULT_CONFIG=$value
+                ;;
             *)
                 echo "WARNING: unknown configuration item '$var'" >&2
                 ;;
@@ -354,6 +359,7 @@ print_config()
 {
     echo "#####################################################################"
     echo "Installing with the following configuration:                         "
+    echo "  Default network configuration:        ${DEFAULT_CONFIG:-none}      "
     echo "#####################################################################"
 }
 
@@ -473,6 +479,10 @@ if [ -f ./install.conf ]; then
     parse_config ./install.conf
 fi
 
+if [ -n "$BISDN_DEFAULT_CONFIG" ]; then
+    DEFAULT_CONFIG=$BISDN_DEFAULT_CONFIG
+fi
+
 print_config
 
 # See if BISDN Linux partition already exists
@@ -480,7 +490,7 @@ old_part=$(eval $detect_bisdn_linux_partition $boot_dev)
 if [ -n "$old_part" ]; then
     # old_part contains partition number of existing BISDN Linux installation
 
-    if [ -z "$BISDN_DEFAULT_CONFIG" ]; then
+    if [ -z "$DEFAULT_CONFIG" ]; then
         # backup existing config
         backup_cfg $boot_dev $old_part
     fi
@@ -591,14 +601,14 @@ if [ "${DO_RESTORE}" = true ]; then
     restore_cfg $backup_tmp_dir $bisdn_linux_mnt
 fi;
 
-if [ -n "$BISDN_DEFAULT_CONFIG" ] && [ "$BISDN_DEFAULT_CONFIG" != "none" ]; then
-    example_path="/usr/share/baseboxd/default_configurations/$BISDN_DEFAULT_CONFIG"
+if [ -n "$DEFAULT_CONFIG" ] && [ "$DEFAULT_CONFIG" != "none" ]; then
+    example_path="/usr/share/baseboxd/default_configurations/$DEFAULT_CONFIG"
     if [ -d "${bisdn_linux_mnt}${example_path}" ]; then
         # copy *.netdev and *.network files, but not e.g. *.md
         cp "${bisdn_linux_mnt}${example_path}/"*.net* \
             "${bisdn_linux_mnt}/${SYSTEMD_NETWORK_CONFDIR}"
     else
-        echo "WARNING: no default config '$BISDN_DEFAULT_CONFIG' found."
+        echo "WARNING: no default config '$DEFAULT_CONFIG' found."
     fi
 fi
 

--- a/scripts/installer/install.sh
+++ b/scripts/installer/install.sh
@@ -250,7 +250,20 @@ create_bisdn_linux_msdos_partition()
     echo "$part"
 }
 
+get_boolean()
+{
+    case "$1" in
+        y|Y|yes|true)
+            echo "true"
+            ;;
+        *)
+            echo "false"
+            ;;
+    esac
+}
+
 DEFAULT_CONFIG=
+KEEP_CONFIG=true
 
 # parse a config file with FOO=bar assignments
 # supports comments (prefixed with #) and continuation via \
@@ -345,6 +358,9 @@ ${line%\"}"
             DEFAULT_CONFIG)
                 DEFAULT_CONFIG=$value
                 ;;
+            KEEP_CONFIG)
+                KEEP_CONFIG=$(get_boolean $value)
+                ;;
             *)
                 echo "WARNING: unknown configuration item '$var'" >&2
                 ;;
@@ -359,6 +375,7 @@ print_config()
 {
     echo "#####################################################################"
     echo "Installing with the following configuration:                         "
+    echo "  Keep existing configuration:          ${KEEP_CONFIG}               "
     echo "  Default network configuration:        ${DEFAULT_CONFIG:-none}      "
     echo "#####################################################################"
 }
@@ -481,6 +498,7 @@ fi
 
 if [ -n "$BISDN_DEFAULT_CONFIG" ]; then
     DEFAULT_CONFIG=$BISDN_DEFAULT_CONFIG
+    KEEP_CONFIG=false
 fi
 
 print_config
@@ -490,7 +508,7 @@ old_part=$(eval $detect_bisdn_linux_partition $boot_dev)
 if [ -n "$old_part" ]; then
     # old_part contains partition number of existing BISDN Linux installation
 
-    if [ -z "$DEFAULT_CONFIG" ]; then
+    if [ "$KEEP_CONFIG" = true ]; then
         # backup existing config
         backup_cfg $boot_dev $old_part
     fi
@@ -599,16 +617,16 @@ platform_setup
 # Restore the network configuration from previous installation
 if [ "${DO_RESTORE}" = true ]; then
     restore_cfg $backup_tmp_dir $bisdn_linux_mnt
-fi;
-
-if [ -n "$DEFAULT_CONFIG" ] && [ "$DEFAULT_CONFIG" != "none" ]; then
-    example_path="/usr/share/baseboxd/default_configurations/$DEFAULT_CONFIG"
-    if [ -d "${bisdn_linux_mnt}${example_path}" ]; then
-        # copy *.netdev and *.network files, but not e.g. *.md
-        cp "${bisdn_linux_mnt}${example_path}/"*.net* \
-            "${bisdn_linux_mnt}/${SYSTEMD_NETWORK_CONFDIR}"
-    else
-        echo "WARNING: no default config '$DEFAULT_CONFIG' found."
+else
+    if [ -n "$DEFAULT_CONFIG" ] && [ "$DEFAULT_CONFIG" != "none" ]; then
+        example_path="/usr/share/baseboxd/default_configurations/$DEFAULT_CONFIG"
+        if [ -d "${bisdn_linux_mnt}${example_path}" ]; then
+            # copy *.netdev and *.network files, but not e.g. *.md
+            cp "${bisdn_linux_mnt}${example_path}/"*.net* \
+                "${bisdn_linux_mnt}/${SYSTEMD_NETWORK_CONFDIR}"
+        else
+            echo "WARNING: no default config '$DEFAULT_CONFIG' found."
+        fi
     fi
 fi
 

--- a/scripts/installer/sharch_body.sh
+++ b/scripts/installer/sharch_body.sh
@@ -12,7 +12,7 @@
 
 echo "Image build date: %%BUILD_DATE%%"
 echo -n "Verifying image checksum ..."
-sha1=$(sed -e '1,/^exit_marker$/d' "$0" | sha1sum | awk '{ print $1 }')
+sha1=$(sed -e '1,/^exit_marker$/d;/^conf_marker$/q' "$0" | sha1sum | awk '{ print $1 }')
 
 payload_sha1=%%IMAGE_SHA1%%
 
@@ -37,14 +37,32 @@ cd $tmp_dir
 echo -n "Preparing image archive ..."
 sed -e '1,/^exit_marker$/d' $archive_path | tar xf - || exit 1
 echo " OK."
+payload_conf="$(sed -e '1,/^conf_marker$/d' $archive_path)"
+
 cd $cur_wd
 if [ -n "$extract" ] ; then
     # stop here
     echo "Image extracted to: $tmp_dir"
+    if [ -n "$payload_conf" ]; then
+       echo "$payload_conf" > $tmp_dir/installer/install.conf
+       echo "Integrated config extracted to: $tmp_dir/installer/install.conf"
+    fi
+
     if [ "$(id -u)" = "0" ] && [ ! -d "$extract" ] ; then
         echo "To un-mount the tmpfs when finished type:  umount $tmp_dir"
     fi
     exit 0
+fi
+
+echo -n "Checking for configuration ... "
+if [ -f "$cur_wd/install.conf" ]; then
+    echo " found install.conf."
+    cp "$cur_wd/install.conf" "$tmp_dir/installer/install.conf"
+elif [ -n "$payload_conf" ]; then
+    echo " found integrated."
+    echo "$payload_conf" > $tmp_dir/installer/install.conf
+else
+    echo " not found, using defaults."
 fi
 
 $tmp_dir/installer/install.sh


### PR DESCRIPTION
In order to more easily customize the BISDN Linux installation, add support for providing configuration values to the installer, either via appended configuration, or via an `install.conf` alongside the installer.

The configuration follows a simple `VARIABLE = VALUE` format, supporting both quoted and unquoted values, and multi-line values via `\` at the end of the line.

For now it supports the following values:

```
# Prepopulate the contents of /home/basebox/.ssh/authorized_keys
AUTHORIZED_SSH_KEYS=
# Select the default network configuration (default=none)
DEFAULT_CONFIG=
# Provide a custom password hash for the basebox user
DEFAULT_PASSWORD=
# Control whether existing configuration of a previous installation is kept (default=true)
KEEP_CONFIG=
```

If `KEEP_CONFIG` is set to `false`, backing previous configuration will be skipped, and this is treated like a fresh install.

All other values only take effect if doing a fresh install (so also if `KEEP_CONFIG` is set to `false`.

**NOTE**: This deprecates passing `BISDN_DEFAULT_CONFIG` via environment.