### PR TITLE
grpc: only build grpc_cli for the target

### DIFF
--- a/recipes-devtools/grpc/grpc_1.60.%.bbappend
+++ b/recipes-devtools/grpc/grpc_1.60.%.bbappend
@@ -9,7 +9,7 @@ SRC_URI:append = " \
 "
 
 # build grpc_cli as well
-EXTRA_OECMAKE:append = " \
+EXTRA_OECMAKE:append:class-target = " \
     -DgRPC_BUILD_CLI=ON \
 "
 


### PR DESCRIPTION
The gRPC package is built twice, once native for the host and once cross-compiled for the target. We only need grpc_cli for the target, and not during the build, so skip building it for the native package.