### PR TITLE
installer: drop separate kernel in image

### DIFF
--- a/recipes-core/images/onie-nos-installer.inc
+++ b/recipes-core/images/onie-nos-installer.inc
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 INHIBIT_DEFAULT_DEPS = "1"
 
 INSTALL_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.tar.xz"
-INSTALL_KERNEL = "${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}"
 
 ONIEIMAGE_DIR ?= "${S}"
 ONIEIMAGE_DIR_INSTALL = "${ONIEIMAGE_DIR}/installer/"
@@ -34,7 +33,6 @@ do_onie_bundle[depends] += "virtual/kernel:do_deploy"
 
 do_onie_bundle () {
     mkdir --parent "${ONIEIMAGE_DIR_INSTALL}"
-    cp "${INSTALL_KERNEL}" "${ONIEIMAGE_DIR_INSTALL}/"
     cp "${INSTALL_ROOTFS}" "${ONIEIMAGE_DIR_INSTALL}/rootfs.tar.xz"
 
     cp "${BISDN_ONIE_ADDITIONS}/installer/${BISDN_ARCH}/install.sh" "${ONIEIMAGE_DIR_INSTALL}/platform.sh"

--- a/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
+++ b/scripts/installer/machine/arm-accton_as4610_30-r0/platform.conf
@@ -116,6 +116,6 @@ create_hw_load_str() {
         ;;
     esac
 
-    echo "usb start; setenv bootargs root=PARTUUID=${bisdn_linux_uuid} rw noinitrd console=\$consoledev,\$baudrate rootdelay=10; ext2load usb 0:${bisdn_linux_part} \$loadaddr boot/uImage;bootm \${loadaddr}${configuration}"
+    echo "usb start; setenv bootargs root=PARTUUID=${bisdn_linux_uuid} rw noinitrd console=\$consoledev,\$baudrate rootdelay=10; ext2load usb 0:${bisdn_linux_part} \$loadaddr boot/fitImage;bootm \${loadaddr}${configuration}"
 }
 

--- a/scripts/installer/u-boot-arch/install.sh
+++ b/scripts/installer/u-boot-arch/install.sh
@@ -58,10 +58,10 @@ platform_install_bootloader_entry()
     local separator=
 
     if [ -f fitImage ]; then
-	cp fitImage $bisdn_linux_mnt/boot/uImage
+	cp fitImage $bisdn_linux_mnt/boot/fitImage
     fi
 
-    if [ ! -f $bisdn_linux_mnt/boot/uImage ]; then
+    if [ ! -f $bisdn_linux_mnt/boot/fitImage ]; then
         echo "Error: No kernel image in root fs"
         exit 1
     fi
@@ -70,7 +70,7 @@ platform_install_bootloader_entry()
     machine_fixups
 
     # Work-around to support yocto warrior-style fit node names which used '@'.
-    if grep -q "kernel@1" $bisdn_linux_mnt/boot/uImage; then
+    if grep -q "kernel@1" $bisdn_linux_mnt/boot/fitImage; then
         separator="@"
     else
         separator="-"

--- a/scripts/installer/u-boot-arch/install.sh
+++ b/scripts/installer/u-boot-arch/install.sh
@@ -57,10 +57,6 @@ platform_install_bootloader_entry()
     local bisdn_linux_mnt=$3
     local separator=
 
-    if [ -f fitImage ]; then
-	cp fitImage $bisdn_linux_mnt/boot/fitImage
-    fi
-
     if [ ! -f $bisdn_linux_mnt/boot/fitImage ]; then
         echo "Error: No kernel image in root fs"
         exit 1


### PR DESCRIPTION
We ship a kernel already in the rootfs, so there is no need to have a second copy of the kernel embedded in the image.

So drop it and the code copying it from u-boot-arch. grub never even used it.

To not have to rename the kernel, switch u-boot-arch to use fitImage directly as the kernel name, matching what we ship in the rootfs.

Should reduce the installer size by a few MiB.