### PR TITLE
distro: bump version to 5.6.3

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -2,7 +2,7 @@ require conf/distro/poky.conf
 
 DISTRO = "bisdn-linux"
 DISTRO_NAME = "BISDN Linux"
-DISTRO_VERSION = "5.6.2"
+DISTRO_VERSION = "5.6.3"
 
 DISTRO_CODENAME = "Ortolana"
 DISTROOVERRIDES = "poky:bisdn-linux"


### PR DESCRIPTION
In preparation for another maintenance release, bump the version to 5.6.3.