### PR TITLE
installer: u-boot-arch: use a separate bootcmd

### DIFF
--- a/scripts/installer/u-boot-arch/install.sh
+++ b/scripts/installer/u-boot-arch/install.sh
@@ -84,7 +84,8 @@ platform_install_bootloader_entry()
     (cat <<EOF
 hw_load $hw_load_str
 copy_img echo "Loading BISDN Linux image..." && run hw_load
-nos_bootcmd run copy_img && setenv bootargs quiet console=\$consoledev,\$baudrate && bootm \$loadaddr
+bisdn_bootcmd run copy_img && setenv bootargs quiet console=\$consoledev,\$baudrate && bootm \$loadaddr
+nos_bootcmd run bisdn_bootcmd
 EOF
     ) > /tmp/env.txt
 


### PR DESCRIPTION
Currently we use nos_bootcmd for the full command to boot BISDN-Linux. While this is the intended way to use it, when entering installer mode, ONIE makes the installer mode sticky by overwriting nos_bootcmd with true.

Since nos_bootcmd contains installation specific information like the rootfs UUID, it is non-trivial to reconstruct if one actually decides to not install something.

To make this easier to undo, move our boot command to its own variable bisdn_bootcmd, so that nos_bootcmd just becomes "run bisdn_bootcmd".

This way undoing the sticky installer mode becomes just

```
$ fw_setenv nos_bootcmd "run bisdn_bootcmd"
```