### PR TITLE
v5.x: frr: patch CVE-2025-61099..61107 and CVE-2026-28532

### DIFF
--- a/recipes-protocols/frr/frr/CVE-2025-61099-61107-1.patch
+++ b/recipes-protocols/frr/frr/CVE-2025-61099-61107-1.patch
@@ -1,0 +1,40 @@
+From e21276d430663fd8312940bb3b0ce081957e3d85 Mon Sep 17 00:00:00 2001
+From: Gyorgy Sarvari <skandigraun@gmail.com>
+Date: Sun, 24 Aug 2025 21:17:55 +0800
+Subject: [PATCH] ospfd: Add null check for vty_out in check_tlv_size
+
+From: s1awwhy <seawwhy@163.com>
+
+Add security check for vty_out. Specifically,  Check NULL for vty. If vty is not available, dump info via zlog.
+
+Signed-off-by: s1awwhy <seawwhy@163.com>
+
+CVE: CVE-2025-61099 CVE-2025-61100 CVE-2025-61101 CVE-2025-61102 CVE-2025-61103 CVE-2025-61104 CVE-2025-61105 CVE-2025-61106 CVE-2025-61107
+Upstream-Status: Backport [https://github.com/FRRouting/frr/commit/b7d9b7aa47627b31e4b50795284408ab6de98660]
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+---
+ ospfd/ospf_ext.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/ospfd/ospf_ext.c b/ospfd/ospf_ext.c
+index df0b3b9081..8ca0df3200 100644
+--- a/ospfd/ospf_ext.c
++++ b/ospfd/ospf_ext.c
+@@ -1705,11 +1705,15 @@ static void ospf_ext_lsa_schedule(struct ext_itf *exti, enum lsa_opcode op)
+  * ------------------------------------
+  */
+ 
++/* Check NULL for vty. If vty is not available, dump info via zlog */
+ #define check_tlv_size(size, msg)                                              \
+ 	do {                                                                   \
+ 		if (ntohs(tlvh->length) != size) {                             \
+-			vty_out(vty, "  Wrong %s TLV size: %d(%d). Abort!\n",  \
+-				msg, ntohs(tlvh->length), size);               \
++			if (vty != NULL)                         \
++				vty_out(vty, "  Wrong %s TLV size: %d(%d). Abort!\n",  \
++					msg, ntohs(tlvh->length), size);               \
++			else                                              \
++				zlog_debug("    Wrong %s TLV size: %d(%d). Abort!", msg, ntohs(tlvh->length), size);    \
+ 			return size + TLV_HDR_SIZE;                            \
+ 		}                                                              \
+ 	} while (0)

--- a/recipes-protocols/frr/frr/CVE-2025-61099-61107-2.patch
+++ b/recipes-protocols/frr/frr/CVE-2025-61099-61107-2.patch
@@ -1,0 +1,80 @@
+From d9ed123b814dad7cf4b069de5601c9f279596191 Mon Sep 17 00:00:00 2001
+From: Gyorgy Sarvari <skandigraun@gmail.com>
+Date: Tue, 6 Jan 2026 15:32:32 +0100
+Subject: [PATCH] ospfd: skip subsequent tlvs after invalid length
+
+From: Louis Scalbert <louis.scalbert@6wind.com>
+
+Do not attempt to read subsequent TLVs after an TLV invalid length is
+detected.
+
+Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>
+
+CVE: CVE-2025-61099 CVE-2025-61100 CVE-2025-61101 CVE-2025-61102 CVE-2025-61103 CVE-2025-61104 CVE-2025-61105 CVE-2025-61106 CVE-2025-61107
+Upstream-Status: Backport [https://github.com/FRRouting/frr/commit/33dfc7e7be1ac8b66abbf47c30a709215fbc1926]
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+---
+ ospfd/ospf_ext.c | 6 +++---
+ ospfd/ospf_ri.c  | 6 +++---
+ ospfd/ospf_te.c  | 6 +++---
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/ospfd/ospf_ext.c b/ospfd/ospf_ext.c
+index 8ca0df3200..62b0020148 100644
+--- a/ospfd/ospf_ext.c
++++ b/ospfd/ospf_ext.c
+@@ -1710,11 +1710,11 @@ static void ospf_ext_lsa_schedule(struct ext_itf *exti, enum lsa_opcode op)
+ 	do {                                                                   \
+ 		if (ntohs(tlvh->length) != size) {                             \
+ 			if (vty != NULL)                         \
+-				vty_out(vty, "  Wrong %s TLV size: %d(%d). Abort!\n",  \
++				vty_out(vty, "  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",  \
+ 					msg, ntohs(tlvh->length), size);               \
+ 			else                                              \
+-				zlog_debug("    Wrong %s TLV size: %d(%d). Abort!", msg, ntohs(tlvh->length), size);    \
+-			return size + TLV_HDR_SIZE;                            \
++				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!", msg, ntohs(tlvh->length), size);    \
++			return OSPF_MAX_LSA_SIZE + 1;                            \
+ 		}                                                              \
+ 	} while (0)
+ 
+diff --git a/ospfd/ospf_ri.c b/ospfd/ospf_ri.c
+index 76e6efeb83..7934b25451 100644
+--- a/ospfd/ospf_ri.c
++++ b/ospfd/ospf_ri.c
+@@ -1208,12 +1208,12 @@ static int ospf_router_info_lsa_update(struct ospf_lsa *lsa)
+ 	do {                                                                   \
+ 		if (ntohs(tlvh->length) > size) {                              \
+ 			if (vty != NULL)                                       \
+-				vty_out(vty, "  Wrong %s TLV size: %d(%d)\n",  \
++				vty_out(vty, "  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",  \
+ 					msg, ntohs(tlvh->length), size);       \
+ 			else                                                   \
+-				zlog_debug("    Wrong %s TLV size: %d(%d)",    \
++				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!",    \
+ 					   msg, ntohs(tlvh->length), size);    \
+-			return size + TLV_HDR_SIZE;                            \
++			return OSPF_MAX_LSA_SIZE + 1;                            \
+ 		}                                                              \
+ 	} while (0)
+ 
+diff --git a/ospfd/ospf_te.c b/ospfd/ospf_te.c
+index d187485b9f..850a7039f1 100644
+--- a/ospfd/ospf_te.c
++++ b/ospfd/ospf_te.c
+@@ -3161,12 +3161,12 @@ static void ospf_te_init_ted(struct ls_ted *ted, struct ospf *ospf)
+ 	do {                                                                   \
+ 		if (ntohs(tlvh->length) > size) {                              \
+ 			if (vty != NULL)                                       \
+-				vty_out(vty, "  Wrong %s TLV size: %d(%d)\n",  \
++				vty_out(vty, "  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",  \
+ 					msg, ntohs(tlvh->length), size);       \
+ 			else                                                   \
+-				zlog_debug("    Wrong %s TLV size: %d(%d)",    \
++				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!",    \
+ 					   msg, ntohs(tlvh->length), size);    \
+-			return size + TLV_HDR_SIZE;                            \
++			return OSPF_MAX_LSA_SIZE + 1;                            \
+ 		}                                                              \
+ 	} while (0)
+ 

--- a/recipes-protocols/frr/frr/CVE-2025-61099-61107-3.patch
+++ b/recipes-protocols/frr/frr/CVE-2025-61099-61107-3.patch
@@ -1,0 +1,270 @@
+From eb13bcd9f97b4e13470d4ed6c2deef1c60326778 Mon Sep 17 00:00:00 2001
+From: s1awwhy <seawwhy@163.com>
+Date: Sun, 24 Aug 2025 21:21:23 +0800
+Subject: [PATCH] ospfd: Fix NULL Pointer Deference when dumping link info
+
+When the command debug ospf packet all send/recv detail is enabled in the OSPF
+configuration,  ospfd will dump detailed information of any received or sent
+OSPF packets, either via VTY or through the zlog. However, the original Opaque
+LSA handling code failed to check whether the VTY context and show_opaque_info
+were available, resulting in NULL pointer dereference and crashes in ospfd.
+The patch fixes the Null Pointer Deference Vulnerability in
+show_vty_ext_link_rmt_itf_addr, show_vty_ext_link_adj_sid,
+show_vty_ext_link_lan_adj_sid, show_vty_unknown_tlv,
+show_vty_link_info, show_vty_ext_pref_pref_sid, show_vtY_pref_info.
+Specifically, add NULL check for vty. If vty is not available, dump details
+via zlog.
+
+Signed-off-by: s1awwhy <seawwhy@163.com>
+Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>
+
+CVE: CVE-2025-61099 CVE-2025-61100 CVE-2025-61101 CVE-2025-61102 CVE-2025-61103 CVE-2025-61104 CVE-2025-61105 CVE-2025-61106 CVE-2025-61107
+Upstream-Status: Backport [https://github.com/FRRouting/frr/commit/034e6fe67078810b952630055614ee5710d1196e]
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+---
+ ospfd/ospf_ext.c | 178 ++++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 128 insertions(+), 50 deletions(-)
+
+diff --git a/ospfd/ospf_ext.c b/ospfd/ospf_ext.c
+index 6f6db1748d97..95017e504e19 100644
+--- a/ospfd/ospf_ext.c
++++ b/ospfd/ospf_ext.c
+@@ -1726,9 +1726,15 @@ static uint16_t show_vty_ext_link_rmt_itf_addr(struct vty *vty,
+ 
+ 	check_tlv_size(EXT_SUBTLV_RMT_ITF_ADDR_SIZE, "Remote Itf. Address");
+ 
+-	vty_out(vty,
+-		"  Remote Interface Address Sub-TLV: Length %u\n	Address: %pI4\n",
+-		ntohs(top->header.length), &top->value);
++	if (vty != NULL) {
++		vty_out(vty,
++			"  Remote Interface Address Sub-TLV: Length %u\n	Address: %pI4\n",
++			ntohs(top->header.length), &top->value);
++	} else {
++		zlog_debug("  Remote Interface Address Sub-TLV: Length %u",
++			   ntohs(top->header.length));
++		zlog_debug("  Address: %pI4", &top->value);
++	}
+ 
+ 	return TLV_SIZE(tlvh);
+ }
+@@ -1745,14 +1751,27 @@ static uint16_t show_vty_ext_link_adj_sid(struct vty *vty,
+ 			      : SID_INDEX_SIZE(EXT_SUBTLV_ADJ_SID_SIZE);
+ 	check_tlv_size(tlv_size, "Adjacency SID");
+ 
+-	vty_out(vty,
+-		"  Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\t%s: %u\n",
+-		ntohs(top->header.length), top->flags, top->mtid, top->weight,
+-		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
+-								     : "Index",
+-		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
+-			? GET_LABEL(ntohl(top->value))
+-			: ntohl(top->value));
++	if (vty != NULL) {
++		vty_out(vty,
++			"  Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\t%s: %u\n",
++			ntohs(top->header.length), top->flags, top->mtid, top->weight,
++			CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
++									     : "Index",
++			CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
++				? GET_LABEL(ntohl(top->value))
++				: ntohl(top->value));
++	} else {
++		zlog_debug("  Adj-SID Sub-TLV: Length %u", ntohs(top->header.length));
++		zlog_debug("    Flags: 0x%x", top->flags);
++		zlog_debug("    MT-ID:0x%x", top->mtid);
++		zlog_debug("    Weight: 0x%x", top->weight);
++		zlog_debug("    %s: %u",
++			   CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
++										: "Index",
++			   CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
++				   ? GET_LABEL(ntohl(top->value))
++				   : ntohl(top->value));
++	}
+ 
+ 	return TLV_SIZE(tlvh);
+ }
+@@ -1770,15 +1789,29 @@ static uint16_t show_vty_ext_link_lan_adj_sid(struct vty *vty,
+ 			      : SID_INDEX_SIZE(EXT_SUBTLV_LAN_ADJ_SID_SIZE);
+ 	check_tlv_size(tlv_size, "LAN-Adjacency SID");
+ 
+-	vty_out(vty,
+-		"  LAN-Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\tNeighbor ID: %pI4\n\t%s: %u\n",
+-		ntohs(top->header.length), top->flags, top->mtid, top->weight,
+-		&top->neighbor_id,
+-		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
+-								     : "Index",
+-		CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
+-			? GET_LABEL(ntohl(top->value))
+-			: ntohl(top->value));
++	if (vty != NULL) {
++		vty_out(vty,
++			"  LAN-Adj-SID Sub-TLV: Length %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\tWeight: 0x%x\n\tNeighbor ID: %pI4\n\t%s: %u\n",
++			ntohs(top->header.length), top->flags, top->mtid, top->weight,
++			&top->neighbor_id,
++			CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
++									     : "Index",
++			CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
++				? GET_LABEL(ntohl(top->value))
++				: ntohl(top->value));
++	} else {
++		zlog_debug("  LAN-Adj-SID Sub-TLV: Length %u", ntohs(top->header.length));
++		zlog_debug("    Flags: 0x%x", top->flags);
++		zlog_debug("    MT-ID:0x%x", top->mtid);
++		zlog_debug("    Weight: 0x%x", top->weight);
++		zlog_debug("    Neighbor ID: %pI4", &top->neighbor_id);
++		zlog_debug("    %s: %u",
++			   CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG) ? "Label"
++										: "Index",
++			   CHECK_FLAG(top->flags, EXT_SUBTLV_LINK_ADJ_SID_VFLG)
++				   ? GET_LABEL(ntohl(top->value))
++				   : ntohl(top->value));
++	}
+ 
+ 	return TLV_SIZE(tlvh);
+ }
+@@ -1787,13 +1820,21 @@ static uint16_t show_vty_unknown_tlv(struct vty *vty, struct tlv_header *tlvh,
+ 				     size_t buf_size)
+ {
+ 	if (TLV_SIZE(tlvh) > buf_size) {
+-		vty_out(vty, "    TLV size %d exceeds buffer size. Abort!",
+-			TLV_SIZE(tlvh));
++		if (vty != NULL)
++			vty_out(vty, "    TLV size %d exceeds buffer size. Abort!", TLV_SIZE(tlvh));
++		else
++			zlog_debug("    TLV size %d exceeds buffer size. Abort!", TLV_SIZE(tlvh));
++
+ 		return buf_size;
+ 	}
+ 
+-	vty_out(vty, "    Unknown TLV: [type(0x%x), length(0x%x)]\n",
+-		ntohs(tlvh->type), ntohs(tlvh->length));
++	if (vty != NULL) {
++		vty_out(vty, "    Unknown TLV: [type(0x%x), length(0x%x)]\n",
++			ntohs(tlvh->type), ntohs(tlvh->length));
++	} else {
++		zlog_debug("    Unknown TLV: [type(0x%x), length(0x%x)]\n",
++			   ntohs(tlvh->type), ntohs(tlvh->length));
++	}
+ 
+ 	return TLV_SIZE(tlvh);
+ }
+@@ -1809,18 +1850,30 @@ static uint16_t show_vty_link_info(struct vty *vty, struct tlv_header *ext,
+ 
+ 	/* Verify that TLV length is valid against remaining buffer size */
+ 	if (length > buf_size) {
+-		vty_out(vty,
+-			"  Extended Link TLV size %d exceeds buffer size. Abort!\n",
+-			length);
++		if (vty != NULL) {
++			vty_out(vty,
++				"  Extended Link TLV size %d exceeds buffer size. Abort!\n",
++				length);
++		} else {
++			zlog_debug("  Extended Link TLV size %d exceeds buffer size. Abort!",
++				   length);
++		}
+ 		return buf_size;
+ 	}
+ 
+-	vty_out(vty,
+-		"  Extended Link TLV: Length %u\n	Link Type: 0x%x\n"
+-		"	Link ID: %pI4\n",
+-		ntohs(top->header.length), top->link_type,
+-		&top->link_id);
+-	vty_out(vty, "	Link data: %pI4\n", &top->link_data);
++	if (vty != NULL) {
++		vty_out(vty,
++			"  Extended Link TLV: Length %u\n	Link Type: 0x%x\n"
++			"	Link ID: %pI4\n",
++			ntohs(top->header.length), top->link_type,
++			&top->link_id);
++		vty_out(vty, "	Link data: %pI4\n", &top->link_data);
++	} else {
++		zlog_debug("  Extended Link TLV: Length %u", ntohs(top->header.length));
++		zlog_debug("    Link Type: 0x%x", top->link_type);
++		zlog_debug("    Link ID: %pI4", &top->link_id);
++		zlog_debug("    Link data: %pI4", &top->link_data);
++	}
+ 
+ 	/* Skip Extended TLV and parse sub-TLVs */
+ 	length -= EXT_TLV_LINK_SIZE;
+@@ -1886,15 +1939,28 @@ static uint16_t show_vty_ext_pref_pref_sid(struct vty *vty,
+ 			      : SID_INDEX_SIZE(EXT_SUBTLV_PREFIX_SID_SIZE);
+ 	check_tlv_size(tlv_size, "Prefix SID");
+ 
+-	vty_out(vty,
+-		"  Prefix SID Sub-TLV: Length %u\n\tAlgorithm: %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\t%s: %u\n",
+-		ntohs(top->header.length), top->algorithm, top->flags,
+-		top->mtid,
+-		CHECK_FLAG(top->flags, EXT_SUBTLV_PREFIX_SID_VFLG) ? "Label"
+-								   : "Index",
+-		CHECK_FLAG(top->flags, EXT_SUBTLV_PREFIX_SID_VFLG)
+-			? GET_LABEL(ntohl(top->value))
+-			: ntohl(top->value));
++	if (vty != NULL) {
++		vty_out(vty,
++			"  Prefix SID Sub-TLV: Length %u\n\tAlgorithm: %u\n\tFlags: 0x%x\n\tMT-ID:0x%x\n\t%s: %u\n",
++			ntohs(top->header.length), top->algorithm, top->flags,
++			top->mtid,
++			CHECK_FLAG(top->flags, EXT_SUBTLV_PREFIX_SID_VFLG) ? "Label"
++									   : "Index",
++			CHECK_FLAG(top->flags, EXT_SUBTLV_PREFIX_SID_VFLG)
++				? GET_LABEL(ntohl(top->value))
++				: ntohl(top->value));
++	} else {
++		zlog_debug("  Prefix SID Sub-TLV: Length %u", ntohs(top->header.length));
++		zlog_debug("    Algorithm: %u", top->algorithm);
++		zlog_debug("    Flags: 0x%x", top->flags);
++		zlog_debug("    MT-ID:0x%x", top->mtid);
++		zlog_debug("    %s: %u",
++			   CHECK_FLAG(top->flags, EXT_SUBTLV_PREFIX_SID_VFLG) ? "Label"
++									      : "Index",
++			   CHECK_FLAG(top->flags, EXT_SUBTLV_PREFIX_SID_VFLG)
++				   ? GET_LABEL(ntohl(top->value))
++				   : ntohl(top->value));
++	}
+ 
+ 	return TLV_SIZE(tlvh);
+ }
+@@ -1910,17 +1976,29 @@ static uint16_t show_vty_pref_info(struct vty *vty, struct tlv_header *ext,
+ 
+ 	/* Verify that TLV length is valid against remaining buffer size */
+ 	if (length > buf_size) {
+-		vty_out(vty,
+-			"  Extended Link TLV size %d exceeds buffer size. Abort!\n",
+-			length);
++		if (vty != NULL) {
++			vty_out(vty, "  Extended Link TLV size %d exceeds buffer size. Abort!\n",
++				length);
++		} else {
++			zlog_debug("  Extended Link TLV size %d exceeds buffer size. Abort!",
++				   length);
++		}
+ 		return buf_size;
+ 	}
+ 
+-	vty_out(vty,
+-		"  Extended Prefix TLV: Length %u\n\tRoute Type: %u\n"
+-		"\tAddress Family: 0x%x\n\tFlags: 0x%x\n\tAddress: %pI4/%u\n",
+-		ntohs(top->header.length), top->route_type, top->af, top->flags,
+-		&top->address, top->pref_length);
++	if (vty != NULL) {
++		vty_out(vty,
++			"  Extended Prefix TLV: Length %u\n\tRoute Type: %u\n"
++			"\tAddress Family: 0x%x\n\tFlags: 0x%x\n\tAddress: %pI4/%u\n",
++			ntohs(top->header.length), top->route_type, top->af, top->flags,
++			&top->address, top->pref_length);
++	} else {
++		zlog_debug("  Extended Prefix TLV: Length %u", ntohs(top->header.length));
++		zlog_debug("    Route Type: %u", top->route_type);
++		zlog_debug("    Address Family: 0x%x", top->af);
++		zlog_debug("    Flags: 0x%x", top->flags);
++		zlog_debug("    Address: %pI4/%u", &top->address, top->pref_length);
++	}
+ 
+ 	/* Skip Extended Prefix TLV and parse sub-TLVs */
+ 	length -= EXT_TLV_PREFIX_SIZE;
+-- 
+2.54.0
+

--- a/recipes-protocols/frr/frr/CVE-2026-28532.patch
+++ b/recipes-protocols/frr/frr/CVE-2026-28532.patch
@@ -1,0 +1,311 @@
+From d3e8aedb87671f38db59b0df908e25e1d4af027d Mon Sep 17 00:00:00 2001
+From: Jafar Al-Gharaibeh <jafar@atcorp.com>
+Date: Wed, 4 Mar 2026 12:38:46 -0600
+Subject: [PATCH] ospfd: harden TE/SR TLV iteration against malformed lengths
+
+Use 32-bit counters and per-iteration TLV size bounds checks
+in OSPF TE/SR TLV parsers so malformed opaque LSAs cannot wrap
+loop accounting and advance pointers beyond the LSA buffer.
+
+- Change loop accumulators from 16-bit to 32-bit (uint32_t) to
+  prevent wraparound
+- Rework TLV iteration so pointer advancement is controlled in-loop
+- Add per-iteration guard before advancing:
+  - `tlv_size <= (len - sum)` (or `length - sum`)
+- On malformed size, parser now logs and exits/breaks the loop
+  safely instead of stepping past buffer limits
+
+CVE: CVE-2026-28532
+Upstream-Status: Backport [https://github.com/FRRouting/frr/commit/f098decf02987fbf1c891766c1516ac832adadfd]
+
+Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ ospfd/ospf_sr.c | 50 ++++++++++++++++++++++++++++++--------
+ ospfd/ospf_te.c | 64 +++++++++++++++++++++++++++++++++++++++----------
+ 2 files changed, 91 insertions(+), 23 deletions(-)
+
+diff --git a/ospfd/ospf_sr.c b/ospfd/ospf_sr.c
+index 0588ade134a9..2223e6a39aa2 100644
+--- a/ospfd/ospf_sr.c
++++ b/ospfd/ospf_sr.c
+@@ -989,7 +989,8 @@ static struct sr_link *get_ext_link_sid(struct tlv_header *tlvh, size_t size)
+ 	struct ext_subtlv_rmt_itf_addr *rmt_itf;
+ 
+ 	struct tlv_header *sub_tlvh;
+-	uint16_t length = 0, sum = 0, i = 0;
++	uint32_t length = 0, sum = 0;
++	uint16_t i = 0;
+ 
+ 	/* Check TLV size */
+ 	if ((ntohs(tlvh->length) > size)
+@@ -1004,7 +1005,15 @@ static struct sr_link *get_ext_link_sid(struct tlv_header *tlvh, size_t size)
+ 	length = ntohs(tlvh->length) - EXT_TLV_LINK_SIZE;
+ 	sub_tlvh = (struct tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE
+ 					 + EXT_TLV_LINK_SIZE);
+-	for (; sum < length && sub_tlvh; sub_tlvh = TLV_HDR_NEXT(sub_tlvh)) {
++	for (; sum < length && sub_tlvh;) {
++		uint32_t tlv_size = TLV_SIZE(sub_tlvh);
++
++		if (tlv_size > length - sum) {
++			zlog_warn("Malformed Extended Link sub-TLV size %u (remaining %u)",
++				  tlv_size, length - sum);
++			break;
++		}
++
+ 		switch (ntohs(sub_tlvh->type)) {
+ 		case EXT_SUBTLV_ADJ_SID:
+ 			adj_sid = (struct ext_subtlv_adj_sid *)sub_tlvh;
+@@ -1045,7 +1054,9 @@ static struct sr_link *get_ext_link_sid(struct tlv_header *tlvh, size_t size)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(sub_tlvh);
++		sum += tlv_size;
++		if (sum < length)
++			sub_tlvh = TLV_HDR_NEXT(sub_tlvh);
+ 	}
+ 
+ 	IPV4_ADDR_COPY(&srl->itf_addr, &link->link_data);
+@@ -1066,7 +1077,7 @@ static struct sr_prefix *get_ext_prefix_sid(struct tlv_header *tlvh,
+ 	struct ext_subtlv_prefix_sid *psid;
+ 
+ 	struct tlv_header *sub_tlvh;
+-	uint16_t length = 0, sum = 0;
++	uint32_t length = 0, sum = 0;
+ 
+ 	/* Check TLV size */
+ 	if ((ntohs(tlvh->length) > size)
+@@ -1081,7 +1092,15 @@ static struct sr_prefix *get_ext_prefix_sid(struct tlv_header *tlvh,
+ 	length = ntohs(tlvh->length) - EXT_TLV_PREFIX_SIZE;
+ 	sub_tlvh = (struct tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE
+ 					 + EXT_TLV_PREFIX_SIZE);
+-	for (; sum < length && sub_tlvh; sub_tlvh = TLV_HDR_NEXT(sub_tlvh)) {
++	for (; sum < length && sub_tlvh;) {
++		uint32_t tlv_size = TLV_SIZE(sub_tlvh);
++
++		if (tlv_size > length - sum) {
++			zlog_warn("Malformed Extended Prefix sub-TLV size %u (remaining %u)",
++				  tlv_size, length - sum);
++			break;
++		}
++
+ 		switch (ntohs(sub_tlvh->type)) {
+ 		case EXT_SUBTLV_PREFIX_SID:
+ 			psid = (struct ext_subtlv_prefix_sid *)sub_tlvh;
+@@ -1106,7 +1125,9 @@ static struct sr_prefix *get_ext_prefix_sid(struct tlv_header *tlvh,
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(sub_tlvh);
++		sum += tlv_size;
++		if (sum < length)
++			sub_tlvh = TLV_HDR_NEXT(sub_tlvh);
+ 	}
+ 
+ 	osr_debug("  |-  Found SID %u for prefix %pFX", srp->sid,
+@@ -1374,7 +1395,7 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
+ 	struct ri_sr_tlv_sid_label_range *ri_srlb = NULL;
+ 	struct ri_sr_tlv_sr_algorithm *algo = NULL;
+ 	struct sr_block srgb;
+-	uint16_t length = 0, sum = 0;
++	uint32_t length = 0, sum = 0;
+ 	uint8_t msd = 0;
+ 
+ 	osr_debug("SR (%s): Process Router Information LSA 4.0.0.%u from %pI4",
+@@ -1402,8 +1423,15 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
+ 	srgb.range_size = 0;
+ 	srgb.lower_bound = 0;
+ 
+-	for (tlvh = TLV_HDR_TOP(lsah); (sum < length) && (tlvh != NULL);
+-	     tlvh = TLV_HDR_NEXT(tlvh)) {
++	for (tlvh = TLV_HDR_TOP(lsah); (sum < length) && (tlvh != NULL);) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
++
++		if (tlv_size > length - sum) {
++			zlog_warn("Malformed RI TLV size %u (remaining %u)", tlv_size,
++				  length - sum);
++			break;
++		}
++
+ 		switch (ntohs(tlvh->type)) {
+ 		case RI_SR_TLV_SR_ALGORITHM:
+ 			algo = (struct ri_sr_tlv_sr_algorithm *)tlvh;
+@@ -1420,7 +1448,9 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < length)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Check if Segment Routing Capabilities has been found */
+diff --git a/ospfd/ospf_te.c b/ospfd/ospf_te.c
+index ab2cf7a0be8a..b2498eb6fb4e 100644
+--- a/ospfd/ospf_te.c
++++ b/ospfd/ospf_te.c
+@@ -2119,7 +2119,7 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct ls_attributes *old, attr = {};
+ 	struct tlv_header *tlvh;
+ 	void *value;
+-	uint16_t len, sum;
++	uint32_t len, sum;
+ 	uint8_t lsa_id;
+ 
+ 	/* Initialize Attribute */
+@@ -2149,11 +2149,19 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 
+ 	sum = sizeof(struct tlv_header);
+ 	/* Browse sub-TLV and fulfill Link State Attributes */
+-	for (tlvh = TLV_DATA(tlvh); sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {
++	tlvh = TLV_DATA(tlvh);
++	while (sum < len) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
+ 		uint32_t val32, tab32[2];
+ 		float valf, tabf[8];
+ 		struct in_addr addr;
+ 
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed TE sub-TLV size %u (remaining %u)", tlv_size,
++				  len - sum);
++			break;
++		}
++
+ 		value = TLV_DATA(tlvh);
+ 		switch (ntohs(tlvh->type)) {
+ 		case TE_LINK_SUBTLV_LCLIF_IPADDR:
+@@ -2248,7 +2256,9 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Get corresponding Edge from Link State Data Base */
+@@ -2348,7 +2358,7 @@ static int ospf_te_delete_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct tlv_header *tlvh;
+ 	struct in_addr addr;
+ 	struct ls_edge_key key = {.family = AF_UNSPEC};
+-	uint16_t len, sum;
++	uint32_t len, sum;
+ 	uint8_t lsa_id;
+ 
+ 	/* Initialize TLV browsing */
+@@ -2360,14 +2370,25 @@ static int ospf_te_delete_te(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	sum = sizeof(struct tlv_header);
+ 
+ 	/* Browse sub-TLV to find Link ID */
+-	for (tlvh = TLV_DATA(tlvh); sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {
++	tlvh = TLV_DATA(tlvh);
++	while (sum < len) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
++
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed TE sub-TLV size %u (remaining %u)", tlv_size,
++				  len - sum);
++			break;
++		}
++
+ 		if (ntohs(tlvh->type) == TE_LINK_SUBTLV_LCLIF_IPADDR) {
+ 			memcpy(&addr, TLV_DATA(tlvh), TE_LINK_SUBTLV_DEF_SIZE);
+ 			key.family = AF_INET;
+ 			IPV4_ADDR_COPY(&key.k.addr, &addr);
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 	if (key.family == AF_UNSPEC)
+ 		return 0;
+@@ -2442,7 +2463,7 @@ static int ospf_te_parse_ri(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct ls_node *node;
+ 	struct lsa_header *lsah = lsa->data;
+ 	struct tlv_header *tlvh;
+-	uint16_t len = 0, sum = 0;
++	uint32_t len = 0, sum = 0;
+ 
+ 	/* Get vertex / Node from LSA Advertised Router ID */
+ 	vertex = get_vertex(ted, lsa);
+@@ -2453,13 +2474,18 @@ static int ospf_te_parse_ri(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 
+ 	/* Initialize TLV browsing */
+ 	len = lsa->size - OSPF_LSA_HEADER_SIZE;
+-	for (tlvh = TLV_HDR_TOP(lsah); sum < len && tlvh;
+-	     tlvh = TLV_HDR_NEXT(tlvh)) {
++	for (tlvh = TLV_HDR_TOP(lsah); sum < len && tlvh;) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
+ 		struct ri_sr_tlv_sr_algorithm *algo;
+ 		struct ri_sr_tlv_sid_label_range *range;
+ 		struct ri_sr_tlv_node_msd *msd;
+ 		uint32_t size, lower;
+ 
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed RI TLV size %u (remaining %u)", tlv_size, len - sum);
++			break;
++		}
++
+ 		switch (ntohs(tlvh->type)) {
+ 		case RI_SR_TLV_SR_ALGORITHM:
+ 			if (TLV_BODY_SIZE(tlvh) < 1 ||
+@@ -2544,7 +2570,9 @@ static int ospf_te_parse_ri(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Vertex has been created or updated: export it */
+@@ -2756,7 +2784,8 @@ static int ospf_te_parse_ext_link(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	struct ext_tlv_link *ext;
+ 	struct ls_edge *edge;
+ 	struct ls_attributes *atr;
+-	uint16_t len = 0, sum = 0, i;
++	uint32_t len = 0, sum = 0;
++	uint16_t i;
+ 	uint32_t label;
+ 
+ 	/* Get corresponding Edge from Link State Data Base */
+@@ -2790,11 +2819,18 @@ static int ospf_te_parse_ext_link(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 	len -= EXT_TLV_LINK_SIZE;
+ 	tlvh = (struct tlv_header *)((char *)(ext) + TLV_HDR_SIZE
+ 				     + EXT_TLV_LINK_SIZE);
+-	for (; sum < len; tlvh = TLV_HDR_NEXT(tlvh)) {
++	for (; sum < len;) {
++		uint32_t tlv_size = TLV_SIZE(tlvh);
+ 		struct ext_subtlv_adj_sid *adj;
+ 		struct ext_subtlv_lan_adj_sid *ladj;
+ 		struct ext_subtlv_rmt_itf_addr *rmt;
+ 
++		if (tlv_size > len - sum) {
++			zlog_warn("Malformed Extended Link sub-TLV size %u (remaining %u)",
++				  tlv_size, len - sum);
++			break;
++		}
++
+ 		switch (ntohs(tlvh->type)) {
+ 		case EXT_SUBTLV_ADJ_SID:
+ 			if (TLV_BODY_SIZE(tlvh) != EXT_SUBTLV_ADJ_SID_SIZE)
+@@ -2873,7 +2909,9 @@ static int ospf_te_parse_ext_link(struct ls_ted *ted, struct ospf_lsa *lsa)
+ 		default:
+ 			break;
+ 		}
+-		sum += TLV_SIZE(tlvh);
++		sum += tlv_size;
++		if (sum < len)
++			tlvh = TLV_HDR_NEXT(tlvh);
+ 	}
+ 
+ 	/* Export Link State Edge if needed */
+-- 
+2.54.0
+

--- a/recipes-protocols/frr/frr_9.0.5.bb
+++ b/recipes-protocols/frr/frr_9.0.5.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/FRRouting/frr.git;protocol=https;branch=stable/9.0 \
            file://CVE-2025-61099-61107-1.patch \
            file://CVE-2025-61099-61107-2.patch \
            file://CVE-2025-61099-61107-3.patch \
+           file://CVE-2026-28532.patch \
            "
 
 SRCREV = "c1610fbddd11ab6250049293b87f035d4af2541d"

--- a/recipes-protocols/frr/frr_9.0.5.bb
+++ b/recipes-protocols/frr/frr_9.0.5.bb
@@ -11,6 +11,9 @@ LIC_FILES_CHKSUM = "file://doc/licenses/GPL-2.0;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRC_URI = "git://github.com/FRRouting/frr.git;protocol=https;branch=stable/9.0 \
            file://frr.pam \
+           file://CVE-2025-61099-61107-1.patch \
+           file://CVE-2025-61099-61107-2.patch \
+           file://CVE-2025-61099-61107-3.patch \
            "
 
 SRCREV = "c1610fbddd11ab6250049293b87f035d4af2541d"


### PR DESCRIPTION
Details:

https://nvd.nist.gov/vuln/detail/CVE-2025-61099
https://nvd.nist.gov/vuln/detail/CVE-2025-61100
https://nvd.nist.gov/vuln/detail/CVE-2025-61101
https://nvd.nist.gov/vuln/detail/CVE-2025-61102
https://nvd.nist.gov/vuln/detail/CVE-2025-61103
https://nvd.nist.gov/vuln/detail/CVE-2025-61104
https://nvd.nist.gov/vuln/detail/CVE-2025-61105
https://nvd.nist.gov/vuln/detail/CVE-2025-61106
https://nvd.nist.gov/vuln/detail/CVE-2025-61107

The NVD advisory refernces a PR[1] that contains only an unfinished, and ultimately unmerged attempt at the fixes. The actual solution comes from a different PR[2]. These patches are 3 commits from that PR. The last commit wasn't backported, because it is just code formatting.

In addition, fix

https://nvd.nist.gov/vuln/detail/CVE-2026-28532

[1]: https://github.com/FRRouting/frr/pull/19480
[2]: https://github.com/FRRouting/frr/pull/19983

Backport of https://github.com/bisdn/meta-bisdn-linux/pull/352