### PR TITLE
add missing Upstream-Status tags to patches

### DIFF
--- a/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
+++ b/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
@@ -19,6 +19,10 @@ only after having authorized the STA in the driver.
 
 Signed-off-by: Jouni Malinen <j@w1.fi>
 (cherry picked from commit 2ab56694f64b05e9d1ac4170f6b2be7d88444c0f)
+
+Upstream-Status: Backport [https://git.w1.fi/cgit/hostap/commit/?id=2ab56694f64b05e9d1ac4170f6b2be7d88444c0f]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/ap/drv_callbacks.c | 10 ++++++++--
  src/ap/ieee802_1x.c    | 19 ++++++++-----------

--- a/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
+++ b/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
@@ -6,6 +6,8 @@ Subject: [PATCH 02/12] netlink: allow listening for neighbor events
 Similar how subscribing to link events works, allow subscribing to
 neighbor events, but only subscribe if any callbacks are populated.
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/drivers/netlink.c      | 22 ++++++++++++++++++++++

--- a/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
+++ b/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
@@ -9,6 +9,8 @@ Add two options for for driver_wired_linux:
 * mac_auth: use MAB (0 = disabled, 1 = kernel MAB, 2 = software
   MAB)
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  hostapd/config_file.c | 13 +++++++++++++

--- a/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
+++ b/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
@@ -23,6 +23,8 @@ TODO:
   detected
 * make mab configurable
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/ap/drv_callbacks.c | 11 +++++-

--- a/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
+++ b/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
@@ -4,6 +4,8 @@ Date: Fri, 14 Feb 2025 10:52:51 +0100
 Subject: [PATCH 05/12] use a timer for mab instead of forcing drivers to set
  it explicitly
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/ap/drv_callbacks.c | 11 ++-------

--- a/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
+++ b/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
@@ -6,6 +6,8 @@ Subject: [PATCH 06/12] drivers: add a linux wired driver
 Add a driver making use of the new-ish LOCKED flags for ports and
 neighbors to implement a wired driver for linux.
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/drivers/driver.h             |   3 +

--- a/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
+++ b/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
@@ -3,6 +3,8 @@ From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 14 Feb 2025 10:59:57 +0100
 Subject: [PATCH 07/12] driver_linux_wired: handle neighs going away
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/drivers/driver_wired_linux.c | 53 +++++++++++++++++++++++++++++++-

--- a/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
+++ b/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
@@ -6,6 +6,8 @@ Subject: [PATCH 08/12] driver_wired_linux: flush all entries on start/stop
 Make sure that there are no fdb entries left on start or stop that may
 unlock traffic unexpectedly.
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/drivers/driver_wired_linux.c | 3 +++

--- a/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
+++ b/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
@@ -10,6 +10,8 @@ configure the port.
 But we cannot configure locked mode while not attached to a bridge, so
 wait until the port has a master (i.e. attached to a bridge).
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/drivers/driver_wired_linux.c | 16 +++++++++++++---

--- a/recipes-connectivity/hostapd/files/0010-driver_wired_linux-unlock-neigh-before-unlocking-por.patch
+++ b/recipes-connectivity/hostapd/files/0010-driver_wired_linux-unlock-neigh-before-unlocking-por.patch
@@ -11,6 +11,8 @@ the STA from hostapd, but keeping the port unlocked.
 Fix this by unlocking the neigh first before unlocking the port,
 properly keeping the STA active.
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/drivers/driver_wired_linux.c | 12 ++++++------

--- a/recipes-connectivity/hostapd/files/0011-driver_wired_linux-add-ifname-to-log-messages.patch
+++ b/recipes-connectivity/hostapd/files/0011-driver_wired_linux-add-ifname-to-log-messages.patch
@@ -9,6 +9,8 @@ hostapd that print messages.
 Should make it clearer where things are happening when running auth on
 multiple ports.
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/drivers/driver_wired_linux.c | 62 +++++++++++++++++---------------

--- a/recipes-connectivity/hostapd/files/0012-MAB-add-MAB-events.patch
+++ b/recipes-connectivity/hostapd/files/0012-MAB-add-MAB-events.patch
@@ -6,6 +6,8 @@ Subject: [PATCH 12/12] MAB: add MAB events
 Generate MAB events for STARTED, SUCCESS and FAILURE, so that scripts can
 log and/or react to MAB specific events.
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/ap/ieee802_1x.c   | 7 +++++++

--- a/recipes-daemons/keepalived/files/2.2.8/0001-add-for-baseboxd-in-service-file.patch
+++ b/recipes-daemons/keepalived/files/2.2.8/0001-add-for-baseboxd-in-service-file.patch
@@ -3,6 +3,8 @@ From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Mon, 22 Mar 2021 18:49:54 +0100
 Subject: [PATCH] add for baseboxd in service file
 
+Upstream-Status: Inappropriate [baseboxd is a BISDN-Linux package]
+
 ---
  keepalived/keepalived.service.in | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-devtools/grpc/files/1.60.1/0001-CMakelists.txt-allow-building-the-grpc_cli-utility-o.patch
+++ b/recipes-devtools/grpc/files/1.60.1/0001-CMakelists.txt-allow-building-the-grpc_cli-utility-o.patch
@@ -3,6 +3,8 @@ From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 15 Jun 2022 17:45:38 +0200
 Subject: [PATCH] CMakelists.txt: allow building the grpc_cli utility only
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  CMakeLists.txt | 19 +++++++++++++++++--

--- a/recipes-devtools/python/python3-ryu/0001-Add-ofdpa_vpws.py-sample-code-for-MPLS-pseudowires.patch
+++ b/recipes-devtools/python/python3-ryu/0001-Add-ofdpa_vpws.py-sample-code-for-MPLS-pseudowires.patch
@@ -52,6 +52,8 @@ mac_peer) and the outer labels.
 This ryu application writes incoming ARP and IP packets to a pcap
 file. Note that outgoing packets are invisible to the controller.
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/app/bisdn/ofdpa_vpws.py | 1297 +++++++++++++++++++++++++++++++++++

--- a/recipes-devtools/python/python3-ryu/0001-Upgrade-eventlet.patch
+++ b/recipes-devtools/python/python3-ryu/0001-Upgrade-eventlet.patch
@@ -1,10 +1,10 @@
-Upstream-Status: backport [https://github.com/faucetsdn/ryu/commit/dfe583bd837902af0276b31eedbc340adc695815]
 
 From dfe583bd837902af0276b31eedbc340adc695815 Mon Sep 17 00:00:00 2001
 From: Josh Bailey <josh@vandervecken.com>
 Date: Tue, 1 Jun 2021 08:02:07 +1200
 Subject: [PATCH] Upgrade eventlet.
 
+Upstream-Status: Backport [https://github.com/faucetsdn/ryu/commit/dfe583bd837902af0276b31eedbc340adc695815]
 ---
  ryu/app/wsgi.py | 11 +++++++++--
  1 file changed, 9 insertions(+), 2 deletions(-)

--- a/recipes-devtools/python/python3-ryu/0001-pcaplib.py-add-option-to-flush-each-packet.patch
+++ b/recipes-devtools/python/python3-ryu/0001-pcaplib.py-add-option-to-flush-each-packet.patch
@@ -17,6 +17,8 @@ from ryu.lib import pcaplib
 pcap_writer = pcaplib.Writer(open("/tmp/ryu.pcap", "wb"))
 pcap_writer.write_pkt(msg.data, flush=True)
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/lib/pcaplib.py | 5 ++++-

--- a/recipes-devtools/python/python3-ryu/0001-remove-hook.patch
+++ b/recipes-devtools/python/python3-ryu/0001-remove-hook.patch
@@ -8,7 +8,8 @@ change. It was only needed for windows, and we don't build for windows,
 and PBR likely won't do the change anymore since easy_install does not
 have a get_script_args anymore in python 3.12.
 
-Upstream-Status: Unsubmitted [Upstream dead]
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  ryu/hooks.py | 19 -------------------

--- a/recipes-devtools/python/python3-ryu/0001-ryu-ofproto-ofproto_common.py-add-OFDPA_EXPERIMENTER.patch
+++ b/recipes-devtools/python/python3-ryu/0001-ryu-ofproto-ofproto_common.py-add-OFDPA_EXPERIMENTER.patch
@@ -4,6 +4,8 @@ Date: Wed, 23 Jun 2021 12:55:23 +0200
 Subject: [PATCH 1/7] ryu/ofproto/ofproto_common.py: add OFDPA_EXPERIMENTER_ID
 
 Identical to OF_EXPERIMENTER_ID_OFDPA in ofdpa-odp.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
 ---
  ryu/ofproto/ofproto_common.py | 1 +
  1 file changed, 1 insertion(+)

--- a/recipes-devtools/python/python3-ryu/0002-Add-ryu-app-bisdn-__init__.py-to-help-python-recogni.patch
+++ b/recipes-devtools/python/python3-ryu/0002-Add-ryu-app-bisdn-__init__.py-to-help-python-recogni.patch
@@ -7,6 +7,8 @@ Subject: [PATCH 2/2] Add ryu/app/bisdn/__init__.py to help python recognize
 Our yocto/ryu setup requires a __init__.py or the python module,
 ofdpa_vpws.py, doesn't get installed.
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/app/bisdn/__init__.py | 0

--- a/recipes-devtools/python/python3-ryu/0002-ryu-ofproto-oxm_fields.py-add-class-OfdpaExperimente.patch
+++ b/recipes-devtools/python/python3-ryu/0002-ryu-ofproto-oxm_fields.py-add-class-OfdpaExperimente.patch
@@ -3,6 +3,8 @@ From: Roger Luethi <roger.luethi@bisdn.de>
 Date: Wed, 23 Jun 2021 13:26:04 +0200
 Subject: [PATCH 2/7] ryu/ofproto/oxm_fields.py: add class OfdpaExperimenter
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/ofproto/oxm_fields.py | 4 ++++

--- a/recipes-devtools/python/python3-ryu/0003-ryu-lib-ofctl_v1_3.py-add-ofdpa-match-fields.patch
+++ b/recipes-devtools/python/python3-ryu/0003-ryu-lib-ofctl_v1_3.py-add-ofdpa-match-fields.patch
@@ -12,6 +12,8 @@ ofdpa_mpls_l2_port.
 
 [1] https://github.com/Broadcom-Switch/of-dpa.git
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 
 ryu/lib/ofctl_v1_3.py: rm unused field names, sort by field number

--- a/recipes-devtools/python/python3-ryu/0004-Add-ryu-ofproto-ofdpa_ext.py.patch
+++ b/recipes-devtools/python/python3-ryu/0004-Add-ryu-ofproto-ofdpa_ext.py.patch
@@ -9,6 +9,8 @@ Reference:
 - ofdpa-2.02-15-jun-2016.json
 - vpws_test_initiation.py (for external names)
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/ofproto/ofdpa_ext.py | 18 ++++++++++++++++++

--- a/recipes-devtools/python/python3-ryu/0005-ryu-ofproto-ofproto_v1_3.py-add-OFDPA-experimenter-o.patch
+++ b/recipes-devtools/python/python3-ryu/0005-ryu-ofproto-ofproto_v1_3.py-add-OFDPA-experimenter-o.patch
@@ -7,6 +7,8 @@ Subject: [PATCH 5/7] ryu/ofproto/ofproto_v1_3.py: add OFDPA experimenter
 Reference: Table Type Paettern ofdpa-2.02-15-jun-2016.json
 in https://github.com/Broadcom-Switch/of-dpa.git
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/ofproto/ofproto_v1_3.py | 4 ++++

--- a/recipes-devtools/python/python3-ryu/0006-Add-ryu-ofproto-ofdpa_actions.py.patch
+++ b/recipes-devtools/python/python3-ryu/0006-Add-ryu-ofproto-ofdpa_actions.py.patch
@@ -4,6 +4,9 @@ Date: Wed, 23 Jun 2021 14:10:27 +0200
 Subject: [PATCH 6/7] Add ryu/ofproto/ofdpa_actions.py
 
 Code based on nx_actions.py.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 ---
  ryu/ofproto/ofdpa_actions.py | 226 +++++++++++++++++++++++++++++++++++
  1 file changed, 226 insertions(+)

--- a/recipes-devtools/python/python3-ryu/0007-ryu-ofproto-ofproto_v1_3_parser.py-use-ofdpa_actions.patch
+++ b/recipes-devtools/python/python3-ryu/0007-ryu-ofproto-ofproto_v1_3_parser.py-use-ofdpa_actions.patch
@@ -3,6 +3,8 @@ From: Roger Luethi <roger.luethi@bisdn.de>
 Date: Wed, 23 Jun 2021 13:33:55 +0200
 Subject: [PATCH 7/7] ryu/ofproto/ofproto_v1_3_parser.py: use ofdpa_actions
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/ofproto/ofproto_v1_3_parser.py | 8 ++++++++

--- a/recipes-devtools/python/python3-ryu/0008-ryu-ofproto-ofproto_v1_3.py-add-allow_vlan_translati.patch
+++ b/recipes-devtools/python/python3-ryu/0008-ryu-ofproto-ofproto_v1_3.py-add-allow_vlan_translati.patch
@@ -12,6 +12,8 @@ For compatibility with existing users, keep the old name around.
 
 [1] https://github.com/Broadcom-Switch/of-dpa/blob/master/src/Ryu/OFDPA_TE_2.0/ofdpa/matches.py
 
+Upstream-Status: Inactive-Upstream [lastcommit: 2022-06-09]
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  ryu/ofproto/ofproto_v1_3.py | 1 +

--- a/recipes-kernel/accton-csp7551-mods/files/0001-accton-csp7551-sfp-update-for-Linux-6.1.patch
+++ b/recipes-kernel/accton-csp7551-mods/files/0001-accton-csp7551-sfp-update-for-Linux-6.1.patch
@@ -10,6 +10,8 @@ fix was created manually.
 
 [1] https://github.com/bisdn/meta-open-network-linux/blob/main/scripts/coccinelle/modules/6.1-i2c_remove_sig.cocci
 
+Upstream-Status: Pending
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  .../files/x86-64-accton-csp7551-sfp.c                 | 11 +++++++++++

--- a/recipes-kernel/accton-csp7551-mods/files/0002-accton-csp7551-cpld-update-for-Linux-6.1.patch
+++ b/recipes-kernel/accton-csp7551-mods/files/0002-accton-csp7551-cpld-update-for-Linux-6.1.patch
@@ -12,6 +12,8 @@ spatch --sp-file ./scripts/coccinelle/modules/6.1-i2c_remove_sig.cocci \
 
 [1] https://github.com/bisdn/meta-open-network-linux/blob/main/scripts/coccinelle/modules/6.1-i2c_remove_sig.cocci
 
+Upstream-Status: Pending
+
 Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>
 ---
  .../accton-csp7551-mods/files/accton_i2c_cpld.c       | 11 +++++++++++

--- a/recipes-support/libnl/libnl/0001-route-treat-nhid-changes-as-full-route-replacements.patch
+++ b/recipes-support/libnl/libnl/0001-route-treat-nhid-changes-as-full-route-replacements.patch
@@ -34,6 +34,7 @@ Fix this by checking the nhid of the routes, and only merge if they
 match.
 
 Upstream-Status: Backport [https://github.com/thom311/libnl/commit/655a638d4e1f74be9256a3108ae2abb84827a9ce]
+
 Fixes: 29b71371e764 ("route cache: Fix handling of ipv6 multipath routes")
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---

--- a/recipes-support/libnl/libnl/0002-link-bonding-add-primary-getters-and-setters.patch
+++ b/recipes-support/libnl/libnl/0002-link-bonding-add-primary-getters-and-setters.patch
@@ -6,6 +6,8 @@ Subject: [PATCH 2/7] link/bonding: add primary getters and setters
 Add getters and setters for the primary attribute of active backup
 bonds.
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  include/netlink/route/link/bonding.h |  3 ++

--- a/recipes-support/libnl/libnl/0003-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0003-WIP-add-info-slave-data-support.patch
@@ -3,6 +3,8 @@ From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
 Subject: [PATCH 3/7] WIP: add info slave data support
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  lib/route/link.c          | 71 +++++++++++++++++++++++++++++++++++++++

--- a/recipes-support/libnl/libnl/0004-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0004-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -3,6 +3,8 @@ From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
 Subject: [PATCH 4/7] link/bonding: expose state on enslaved interfaces
 
+Upstream-Status: Pending
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  include/netlink/route/link/bonding.h |   3 +

--- a/recipes-support/libnl/libnl/0005-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0005-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -3,6 +3,8 @@ From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
 Subject: [PATCH 5/7] bridge-vlan: add per vlan stp state object and cache
 
+Upstream-Status: Pending
+
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Co-authored-by: Jonas Gorski <jonas.gorski@bisdn.de>
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

--- a/recipes-support/libnl/libnl/0006-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0006-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -4,6 +4,8 @@ Date: Tue, 1 Mar 2022 12:59:50 +0100
 Subject: [PATCH 6/7] route/route_obj: treat each IPv6 link-local route as
  different
 
+Upstream-Status: Inappropriate [not a proper solution]
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  lib/route/route_obj.c | 29 +++++++++++++++++++++++++++++

--- a/recipes-support/libnl/libnl/0007-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0007-link-ignore-incomplete-bridge-updates.patch
@@ -43,7 +43,8 @@ information about the bridge interface from the cache.
 
 Work around for now by ignoring these updates.
 
-Upstream-Status: Reported [https://github.com/thom311/libnl/issues/377]
+Upstream-Status: Inappropriate [https://github.com/thom311/libnl/issues/377]
+
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  lib/route/link.c | 7 +++++++


### PR DESCRIPTION
Several of our local patches are missing Upstream-Status tags, and newer Yocto versions start complaining about that. So fix it by adding the tags.