### PR TITLE
rofl-common: update to 0.14.0

### DIFF
--- a/recipes-support/rofl-common/rofl-common_0.14.0.bb
+++ b/recipes-support/rofl-common/rofl-common_0.14.0.bb
@@ -1,0 +1,5 @@
+# Copyright (C) 2018 Tobias Jungel <tobias.jungel@bisdn.de>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+require rofl-common.inc
+SRCREV = "f985ce3120a17d4729601e8640755ed1b14e0f90"


### PR DESCRIPTION
Update rofl-common to 0.14.0:

```
f985ce3120a1 Bump version to 0.14.0
ec9ed0b60882 crofconn: do not send echo requests while a barrier is pending
f44fc713305a crofconn: allow checking for pending barrier requests
f9cb069b2076 crofdpt: set a default timeout for barrier requests
4dc8c3535856 configure: update C++ standard to C++14
```