### PR TITLE
rofl-common: drop old version recipe

### DIFF
--- a/recipes-support/rofl-common/rofl-common_0.13.6.bb
+++ b/recipes-support/rofl-common/rofl-common_0.13.6.bb
@@ -1,5 +1,0 @@
-# Copyright (C) 2018 Tobias Jungel <tobias.jungel@bisdn.de>
-# Released under the MIT license (see COPYING.MIT for the terms)
-
-require rofl-common.inc
-SRCREV = "acec351b890eff640e3c8667a90ea88bd0af7ea8"


### PR DESCRIPTION
Drop the accidentally left in place recipe for the old version.