### PR TITLE
systemd: increase {r,w}mem_max

### DIFF
--- a/recipes-core/systemd/files/20-network-io.conf
+++ b/recipes-core/systemd/files/20-network-io.conf
@@ -1,7 +1,7 @@
 net.core.rmem_default=524288
-net.core.rmem_max=8388608
+net.core.rmem_max=16777216
 net.core.wmem_default=524288
-net.core.wmem_max=8388608
+net.core.wmem_max=16777216
 net.core.optmem_max=65536
 net.ipv4.ip_forward=1
 net.ipv4.neigh.default.gc_thresh1=8192


### PR DESCRIPTION
When we enabled route and nexthop deletion notifications to userspace, the amount of notifications sent out increase significantly.

This can lead to notifications being dropped in slower systems if the amount of notifications is very large (e.g. 30k routes being deleted).

So increase the maximum buffer size to compensate for the burstiness of those notifications.