### PR TITLE
full: add bash completions

### DIFF
--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -3,11 +3,13 @@
 
 require minimal.bb
 
-IMAGE_FEATURES += " doc-pkgs package-management"
+IMAGE_FEATURES += " bash-completion-pkgs doc-pkgs package-management"
 
 BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     baseboxd \
     baseboxd-tools \
+    bash-completion \
+    bash-completion-extra \
     bridge-utils  \
     curl \
     docker-moby \


### PR DESCRIPTION
In order to improve the usability, add bash-completion and enable bash-completion packages by default for the image.

This allows bash completion to work for a wide range of commands.

Note that bash-completion-extra installs completions for everything and the kitchen sink. There are many commands in there we will likely never need (chromium, x11 etc), but also a few very helpful ones (ip).